### PR TITLE
chore: bump version to 0.4.0, remove /apple from sync endpoint

### DIFF
--- a/OpenWearablesHealthSDK.podspec
+++ b/OpenWearablesHealthSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'OpenWearablesHealthSDK'
-  s.version      = '0.3.0'
+  s.version      = '0.4.0'
   s.summary      = 'iOS SDK for background health data synchronization to the Open Wearables platform.'
   s.description  = <<-DESC
     Native iOS SDK for secure background health data synchronization from Apple HealthKit

--- a/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
+++ b/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
@@ -133,7 +133,7 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
     internal var syncEndpoint: URL? {
         guard let userId = userId else { return nil }
         guard let base = apiBaseUrl else { return nil }
-        return URL(string: "\(base)/sdk/users/\(userId)/sync/apple")
+        return URL(string: "\(base)/sdk/users/\(userId)/sync")
     }
     
     // MARK: - Init


### PR DESCRIPTION
Platform is passed in the payload, no need for it in the URL.