### PR TITLE
Sync logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.13.0
+
+* **Sync telemetry**: new `/logs` endpoint integration for initial full sync diagnostics.
+  - `historical_data_sync_start` event sent before the first payload with per-type record counts, time range, and device state.
+  - `historical_data_type_sync_end` event sent per data type as each completes (fire-and-forget), with record count, duration, success status, and device state snapshot.
+  - Device state includes battery level/state, thermal state, low power mode, RAM usage, and foreground/background task type.
+  - Types with zero records are excluded from end events.
+  - Start event is sent for both fresh and resumed full exports.
+
 ## 0.12.0
 
 * **Source device name**: added `name` field to the source object in health data payloads, providing human-readable device identification alongside existing device metadata.

--- a/OpenWearablesHealthSDK.podspec
+++ b/OpenWearablesHealthSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'OpenWearablesHealthSDK'
-  s.version      = '0.12.0'
+  s.version      = '0.13.0'
   s.summary      = 'iOS SDK for background health data synchronization to the Open Wearables platform.'
   s.description  = <<-DESC
     Native iOS SDK for secure background health data synchronization from Apple HealthKit

--- a/Sources/OpenWearablesHealthSDK/Internal/SyncLogging.swift
+++ b/Sources/OpenWearablesHealthSDK/Internal/SyncLogging.swift
@@ -1,0 +1,201 @@
+import Foundation
+import UIKit
+import HealthKit
+
+extension OpenWearablesHealthSDK {
+
+    // MARK: - Logs Endpoint
+
+    internal var logsEndpoint: URL? {
+        guard let userId = userId, let base = apiBaseUrl else { return nil }
+        return URL(string: "\(base)/sdk/users/\(userId)/logs")
+    }
+
+    // MARK: - Device State Collection
+
+    internal func collectDeviceStateEvent() -> [String: Any] {
+        let device = UIDevice.current
+        device.isBatteryMonitoringEnabled = true
+
+        let thermalState: String
+        switch ProcessInfo.processInfo.thermalState {
+        case .nominal: thermalState = "nominal"
+        case .fair: thermalState = "fair"
+        case .serious: thermalState = "serious"
+        case .critical: thermalState = "critical"
+        @unknown default: thermalState = "unknown"
+        }
+
+        let batteryState: String
+        switch device.batteryState {
+        case .unknown: batteryState = "unknown"
+        case .unplugged: batteryState = "unplugged"
+        case .charging: batteryState = "charging"
+        case .full: batteryState = "full"
+        @unknown default: batteryState = "unknown"
+        }
+
+        let totalRam = ProcessInfo.processInfo.physicalMemory
+        let availableRam = os_proc_available_memory()
+
+        let bgTimeRemaining = UIApplication.shared.backgroundTimeRemaining
+        let taskType = bgTimeRemaining == .greatestFiniteMagnitude ? "foreground" : "background"
+
+        return [
+            "eventType": "device_state",
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "batteryLevel": device.batteryLevel,
+            "batteryState": batteryState,
+            "isLowPowerMode": ProcessInfo.processInfo.isLowPowerModeEnabled,
+            "thermalState": thermalState,
+            "taskType": taskType,
+            "availableRamBytes": availableRam,
+            "totalRamBytes": totalRam
+        ]
+    }
+
+    // MARK: - Count Samples Per Type
+
+    internal func countSamplesForTypes(
+        _ types: [HKSampleType],
+        startDate: Date?,
+        endDate: Date,
+        completion: @escaping ([String: Int]) -> Void
+    ) {
+        var counts: [String: Int] = [:]
+        let lock = NSLock()
+        let group = DispatchGroup()
+
+        let predicate = HKQuery.predicateForSamples(
+            withStart: startDate ?? .distantPast,
+            end: endDate,
+            options: .strictStartDate
+        )
+
+        for type in types {
+            group.enter()
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: nil
+            ) { _, results, _ in
+                let count = results?.count ?? 0
+                lock.lock()
+                counts[type.identifier] = count
+                lock.unlock()
+                group.leave()
+            }
+            healthStore.execute(query)
+        }
+
+        group.notify(queue: .global(qos: .userInitiated)) {
+            completion(counts)
+        }
+    }
+
+    // MARK: - Sync Start Log
+
+    internal func sendSyncStartLog(
+        types: [HKSampleType],
+        typeCounts: [String: Int],
+        startDate: Date?,
+        endDate: Date,
+        completion: @escaping () -> Void
+    ) {
+        guard let endpoint = logsEndpoint, let credential = authCredential else {
+            completion()
+            return
+        }
+
+        let formatter = ISO8601DateFormatter()
+
+        let dataTypeCounts: [[String: Any]] = types.map {
+            ["type": $0.identifier, "count": typeCounts[$0.identifier] ?? 0]
+        }
+
+        var timeRange: [String: String] = ["endDate": formatter.string(from: endDate)]
+        if let startDate = startDate {
+            timeRange["startDate"] = formatter.string(from: startDate)
+        }
+
+        let startEvent: [String: Any] = [
+            "eventType": "historical_data_sync_start",
+            "timestamp": formatter.string(from: Date()),
+            "dataTypeCounts": dataTypeCounts,
+            "timeRange": timeRange
+        ]
+
+        let body: [String: Any] = [
+            "sdkVersion": OpenWearablesHealthSDK.sdkVersion,
+            "provider": "apple",
+            "events": [startEvent, collectDeviceStateEvent()]
+        ]
+
+        sendLogRequest(endpoint: endpoint, credential: credential, body: body, completion: completion)
+    }
+
+    // MARK: - Per-Type End Log (fire-and-forget, called during sync as each type completes)
+
+    internal func sendTypeEndLog(type: String, success: Bool, recordCount: Int, durationMs: Int) {
+        guard let endpoint = logsEndpoint, let credential = authCredential else { return }
+
+        let endEvent: [String: Any] = [
+            "eventType": "historical_data_type_sync_end",
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "dataType": type,
+            "success": success,
+            "recordCount": recordCount,
+            "durationMs": durationMs
+        ]
+
+        let body: [String: Any] = [
+            "sdkVersion": OpenWearablesHealthSDK.sdkVersion,
+            "provider": "apple",
+            "events": [endEvent, collectDeviceStateEvent()]
+        ]
+
+        sendLogRequest(endpoint: endpoint, credential: credential, body: body) { }
+    }
+
+    // MARK: - Helper: fire end log when a type finishes during full export
+
+    internal func fireTypeCompletedLog(_ typeIdentifier: String) {
+        guard let startTime = fullSyncStartTime else { return }
+        let recordCount = loadSyncState()?.typeProgress[typeIdentifier]?.sentCount ?? 0
+        guard recordCount > 0 else { return }
+        let durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
+        sendTypeEndLog(type: typeIdentifier, success: true, recordCount: recordCount, durationMs: durationMs)
+    }
+
+    // MARK: - Send Log Request
+
+    private func sendLogRequest(
+        endpoint: URL,
+        credential: String,
+        body: [String: Any],
+        completion: @escaping () -> Void
+    ) {
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else {
+            logMessage("Failed to serialize sync log")
+            completion()
+            return
+        }
+
+        var req = URLRequest(url: endpoint)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(to: &req, credential: credential)
+        req.httpBody = data
+
+        let task = foregroundSession.dataTask(with: req) { [weak self] _, response, error in
+            if let error = error {
+                self?.logMessage("Sync log error: \(error.localizedDescription)")
+            } else if let httpResponse = response as? HTTPURLResponse {
+                self?.logMessage("Sync log: HTTP \(httpResponse.statusCode)")
+            }
+            completion()
+        }
+        task.resume()
+    }
+}

--- a/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
+++ b/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
@@ -41,7 +41,7 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
     /// Shared singleton instance.
     public static let shared = OpenWearablesHealthSDK()
     
-    internal static let sdkVersion = "0.12.0"
+    internal static let sdkVersion = "0.13.0"
     
     // MARK: - Public Callbacks
     
@@ -122,6 +122,7 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
     private var isSyncing: Bool = false
     private var syncCancelled: Bool = false
     private let syncLock = NSLock()
+    internal var fullSyncStartTime: Date?
     
     // Network monitoring
     private var networkMonitor: NWPathMonitor?
@@ -588,20 +589,57 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
             _ = startNewSyncState(fullExport: effectiveFullExport, types: queryableTypes)
         }
         
-        processTypesRoundRobin(
-            types: queryableTypes,
-            fullExport: effectiveFullExport,
-            endpoint: endpoint,
-            isBackground: isBackground
-        ) { [weak self] allTypesCompleted in
+        let syncStartTime = Date()
+        
+        let startRoundRobin: () -> Void = { [weak self] in
             guard let self = self else { return }
-            if allTypesCompleted {
-                self.finalizeSyncState()
-            } else {
-                self.logMessage("Sync incomplete - will resume remaining types later")
+            if effectiveFullExport {
+                self.fullSyncStartTime = syncStartTime
             }
-            self.finishSync()
-            completion()
+            self.processTypesRoundRobin(
+                types: queryableTypes,
+                fullExport: effectiveFullExport,
+                endpoint: endpoint,
+                isBackground: isBackground
+            ) { [weak self] allTypesCompleted in
+                guard let self = self else { return }
+                
+                if effectiveFullExport && !allTypesCompleted {
+                    let durationMs = Int(Date().timeIntervalSince(syncStartTime) * 1000)
+                    let state = self.loadSyncState()
+                    for type in queryableTypes {
+                        let typeId = type.identifier
+                        if !(state?.completedTypes.contains(typeId) ?? false) {
+                            let recordCount = state?.typeProgress[typeId]?.sentCount ?? 0
+                            if recordCount > 0 {
+                                self.sendTypeEndLog(type: typeId, success: false, recordCount: recordCount, durationMs: durationMs)
+                            }
+                        }
+                    }
+                }
+                
+                if allTypesCompleted {
+                    self.finalizeSyncState()
+                } else {
+                    self.logMessage("Sync incomplete - will resume remaining types later")
+                }
+                self.fullSyncStartTime = nil
+                self.finishSync()
+                completion()
+            }
+        }
+        
+        if effectiveFullExport {
+            let startDate = syncStartDate()
+            let endDate = Date()
+            countSamplesForTypes(queryableTypes, startDate: startDate, endDate: endDate) { [weak self] counts in
+                guard let self = self else { return }
+                self.sendSyncStartLog(types: queryableTypes, typeCounts: counts, startDate: startDate, endDate: endDate) {
+                    startRoundRobin()
+                }
+            }
+        } else {
+            startRoundRobin()
         }
     }
     
@@ -707,6 +745,7 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
                     self.updateTypeProgress(typeIdentifier: result.type.identifier, sentInChunk: 0, isComplete: true, anchorData: nil)
                 }
                 rrState.completedTypes.insert(result.type.identifier)
+                if fullExport { self.fireTypeCompletedLog(result.type.identifier) }
             }
             
             // Phase 2: Build combined payload from all types that returned data
@@ -860,6 +899,7 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
             }
             self.updateTypeProgress(typeIdentifier: type.identifier, sentInChunk: 0, isComplete: true, anchorData: anchorData)
             rrState.completedTypes.insert(type.identifier)
+            self.fireTypeCompletedLog(type.identifier)
             self.logMessage("  \(self.shortTypeName(type.identifier)): complete (anchor captured)")
             self.captureAnchorsForDoneTypes(types: types, index: index + 1, rrState: rrState, completion: completion)
         }


### PR DESCRIPTION
## Summary
- New `/logs` endpoint integration sending `sync_start`, per-type `sync_end`, and `device_state` events during full exports
- Record counts queried from HealthKit before start event
- Per-type end events fire in real-time as each type completes with device state snapshot