### PR TITLE
feat: extend HealthDataType with 8 additional dietary nutrients

### DIFF
--- a/Sources/OpenWearablesHealthSDK/Internal/Types.swift
+++ b/Sources/OpenWearablesHealthSDK/Internal/Types.swift
@@ -65,6 +65,14 @@ public enum HealthDataType: String, CaseIterable, Sendable {
     case dietaryCarbohydrates
     case dietaryProtein
     case dietaryFatTotal
+    case dietaryFatSaturated
+    case dietaryFatMonounsaturated
+    case dietaryFatPolyunsaturated
+    case dietaryFiber
+    case dietarySugar
+    case dietarySodium
+    case dietaryCholesterol
+    case dietaryCaffeine
     case dietaryWater
     
     // Workout
@@ -162,6 +170,22 @@ public enum HealthDataType: String, CaseIterable, Sendable {
             return HKObjectType.quantityType(forIdentifier: .dietaryProtein)
         case .dietaryFatTotal:
             return HKObjectType.quantityType(forIdentifier: .dietaryFatTotal)
+        case .dietaryFatSaturated:
+            return HKObjectType.quantityType(forIdentifier: .dietaryFatSaturated)
+        case .dietaryFatMonounsaturated:
+            return HKObjectType.quantityType(forIdentifier: .dietaryFatMonounsaturated)
+        case .dietaryFatPolyunsaturated:
+            return HKObjectType.quantityType(forIdentifier: .dietaryFatPolyunsaturated)
+        case .dietaryFiber:
+            return HKObjectType.quantityType(forIdentifier: .dietaryFiber)
+        case .dietarySugar:
+            return HKObjectType.quantityType(forIdentifier: .dietarySugar)
+        case .dietarySodium:
+            return HKObjectType.quantityType(forIdentifier: .dietarySodium)
+        case .dietaryCholesterol:
+            return HKObjectType.quantityType(forIdentifier: .dietaryCholesterol)
+        case .dietaryCaffeine:
+            return HKObjectType.quantityType(forIdentifier: .dietaryCaffeine)
         case .dietaryWater:
             return HKObjectType.quantityType(forIdentifier: .dietaryWater)
         case .workout:
@@ -542,7 +566,15 @@ extension OpenWearablesHealthSDK {
             return (.count(), "count")
         case HKObjectType.quantityType(forIdentifier: .dietaryCarbohydrates),
              HKObjectType.quantityType(forIdentifier: .dietaryProtein),
-             HKObjectType.quantityType(forIdentifier: .dietaryFatTotal):
+             HKObjectType.quantityType(forIdentifier: .dietaryFatTotal),
+             HKObjectType.quantityType(forIdentifier: .dietaryFatSaturated),
+             HKObjectType.quantityType(forIdentifier: .dietaryFatMonounsaturated),
+             HKObjectType.quantityType(forIdentifier: .dietaryFatPolyunsaturated),
+             HKObjectType.quantityType(forIdentifier: .dietaryFiber),
+             HKObjectType.quantityType(forIdentifier: .dietarySugar),
+             HKObjectType.quantityType(forIdentifier: .dietarySodium),
+             HKObjectType.quantityType(forIdentifier: .dietaryCholesterol),
+             HKObjectType.quantityType(forIdentifier: .dietaryCaffeine):
             return (.gram(), "g")
         case HKObjectType.quantityType(forIdentifier: .dietaryWater):
             return (.liter(), "L")


### PR DESCRIPTION
## Summary

Extends `HealthDataType` with the dietary nutrients iOS nutrition apps commonly log but which the SDK currently drops on the floor: saturated / monounsaturated / polyunsaturated fat, fiber, sugar, sodium, cholesterol, and caffeine. Every one of these has a first-class `HKQuantityTypeIdentifier` and is emitted by FoodNoms, MyFitnessPal, Cronometer, Apple's own Health app, and every other food-logging tool on iOS — they were just invisible to Open Wearables.

### What lands

Every change lives in `Sources/OpenWearablesHealthSDK/Internal/Types.swift`:

| Layer | Change |
| --- | --- |
| `HealthDataType` enum | 8 new cases: `dietaryFatSaturated`, `dietaryFatMonounsaturated`, `dietaryFatPolyunsaturated`, `dietaryFiber`, `dietarySugar`, `dietarySodium`, `dietaryCholesterol`, `dietaryCaffeine` |
| `toHKSampleType()` | 8 new bindings to the matching `HKQuantityTypeIdentifier` constants |
| `_defaultUnit(for:)` | Nutrient-mass extension of the existing `dietaryCarbohydrates`/`Protein`/`FatTotal` rule — all eight default to `(.gram(), "g")`, identical to the existing sibling types |

No ingest-path changes required — these types flow through the generic quantity-sample pipeline. `dietaryWater` is intentionally left alone.

### Why gram for all eight

Matches the existing convention: `_defaultUnit` already returns `.gram()` for `dietaryCarbohydrates`, `dietaryProtein`, and `dietaryFatTotal`. Keeping sodium/cholesterol/caffeine as grams (rather than milligrams) preserves HKUnit-native storage across the SDK; downstream display layers can format as mg for nutrition-label UX.

### Upstream context

The backend-side SeriesType + mapping additions are filed as [the-momentum/open-wearables#961](https://github.com/the-momentum/open-wearables/pull/961). The Flutter wrapper (`open_wearables_health_sdk`) needs a matching enum extension — will file separately.

### Testing notes

I couldn't build locally (Linux workstation, no Swift toolchain). The diff mirrors existing patterns line-for-line, so the syntactic risk is low, but verifying against `swift build` on macOS would be appreciated.

## Test plan

- [ ] `swift build` clean on macOS
- [ ] Request authorization for one of the new types in the example app and confirm the HealthKit permission sheet lists it
- [ ] Log a food in FoodNoms / Apple Health, trigger an SDK sync, and confirm the backend receives `HKQuantityTypeIdentifierDietarySodium` (etc.) at the expected magnitude (grams)