### PR TITLE
feat: add workoutEffortScore + estimatedWorkoutEffortScore to HealthDataType

### DIFF
--- a/Sources/OpenWearablesHealthSDK/Internal/Types.swift
+++ b/Sources/OpenWearablesHealthSDK/Internal/Types.swift
@@ -69,7 +69,11 @@ public enum HealthDataType: String, CaseIterable, Sendable {
     
     // Workout
     case workout
-    
+
+    // Workout Effort (iOS 18.0+ / watchOS 11.0+)
+    case workoutEffortScore
+    case estimatedWorkoutEffortScore
+
     // Aliases (alternative names for the same underlying type)
     case restingEnergy
     case bloodOxygen
@@ -166,6 +170,16 @@ public enum HealthDataType: String, CaseIterable, Sendable {
             return HKObjectType.quantityType(forIdentifier: .dietaryWater)
         case .workout:
             return HKObjectType.workoutType()
+        case .workoutEffortScore:
+            if #available(iOS 18.0, watchOS 11.0, *) {
+                return HKObjectType.quantityType(forIdentifier: .workoutEffortScore)
+            }
+            return nil
+        case .estimatedWorkoutEffortScore:
+            if #available(iOS 18.0, watchOS 11.0, *) {
+                return HKObjectType.quantityType(forIdentifier: .estimatedWorkoutEffortScore)
+            }
+            return nil
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `workoutEffortScore` and `estimatedWorkoutEffortScore` cases to the public `HealthDataType` enum, mapping them to `HKQuantityTypeIdentifier.workoutEffortScore` / `.estimatedWorkoutEffortScore` (iOS 18.0+ / watchOS 11.0+).

## Motivation

Apple HealthKit added these two quantity types in iOS 18 / watchOS 11 (WWDC 2024):
- `workoutEffortScore` — user-rated Borg CR-10 effort (1–10) recorded after a workout via the Fitness app prompt.
- `estimatedWorkoutEffortScore` — Apple Watch automatic algorithmic estimate.

The OW backend ALREADY supports both metric types as `SeriesType.workout_effort_score` / `estimated_workout_effort_score` (see `backend/app/constants/series_types/apple/metric_types.py` in `open-wearables`), and the `/timeseries` API endpoint accepts these as valid `types` parameter values. However, the iOS SDK currently doesn't surface them in `HealthDataType`, so they never get included in `requestAuthorization(types:)` or background sync — meaning the backend always returns empty data for these series regardless of what's actually in the user's HealthKit.

## Verification

Confirmed end-to-end with a real Apple Watch user (179 workouts in 6 weeks) where:
- OW `/timeseries?types=workout_effort_score` returns 200 OK with empty `data: []`
- `grep -i effort` across the SDK's Swift files returns zero hits → confirmed SDK never reads these types

With this change, downstream consumers can opt-in via `sdk.requestAuthorization(types: [.workoutEffortScore, .estimatedWorkoutEffortScore])` (and they'll fall through `toHKSampleType() -> nil` on pre-iOS-18 devices, consistent with the existing `waistCircumference` / `insulinDelivery` pattern).

## Implementation notes

- Did NOT add `@available` annotations on the enum cases themselves to avoid potential `CaseIterable` complications; instead the iOS 18 / watchOS 11 availability check lives inside `toHKSampleType()`, which returns `nil` on older OS versions — same pattern used today for `waistCircumference` (iOS 16+) and `insulinDelivery` (iOS 16+).
- Only `Sources/OpenWearablesHealthSDK/Internal/Types.swift` is touched (15 added, 1 modified line). No other file references the enum's case set (verified via `grep -rn "HealthDataType\." Sources/ Tests/`).

## Test plan

- [ ] `swift build` succeeds
- [ ] `swift test` passes (no existing tests should regress; this is purely additive)
- [ ] On an iOS 18+ device, calling `sdk.requestAuthorization(types: [.workoutEffortScore])` triggers the Health permission sheet showing the new types