### PR TITLE
feat: configurable token-refresh endpoint

### DIFF
--- a/Sources/OpenWearablesHealthSDK/Internal/Keychain.swift
+++ b/Sources/OpenWearablesHealthSDK/Internal/Keychain.swift
@@ -15,6 +15,7 @@ internal class OpenWearablesHealthSdkKeychain {
     private static let baseUrlKey = "baseUrl"
     private static let hostKey = "host"
     private static let customSyncUrlKey = "customSyncUrl"
+    private static let customRefreshUrlKey = "customRefreshUrl"
     private static let syncActiveKey = "syncActive"
     private static let trackedTypesKey = "trackedTypes"
     private static let appInstalledKey = "appInstalled"
@@ -107,6 +108,23 @@ internal class OpenWearablesHealthSdkKeychain {
     static func getCustomSyncUrl() -> String? {
         return defaults.string(forKey: customSyncUrlKey)
     }
+
+    /// Optional override for the token-refresh endpoint. When unset, the SDK
+    /// refreshes against "{apiBaseUrl}/token/refresh". Used by deployments whose
+    /// auth/mint server differs from the data-sync host. Persisted in the shared
+    /// suite so background refresh tasks (run in a fresh process) can read it.
+    static func saveCustomRefreshUrl(_ url: String?) {
+        if let url = url, !url.isEmpty {
+            defaults.set(url, forKey: customRefreshUrlKey)
+        } else {
+            defaults.removeObject(forKey: customRefreshUrlKey)
+        }
+        defaults.synchronize()
+    }
+
+    static func getCustomRefreshUrl() -> String? {
+        return defaults.string(forKey: customRefreshUrlKey)
+    }
     
     // MARK: - Sync Active State
     
@@ -161,6 +179,7 @@ internal class OpenWearablesHealthSdkKeychain {
         delete(key: apiKeyKey)
         defaults.removeObject(forKey: hostKey)
         defaults.removeObject(forKey: customSyncUrlKey)
+        defaults.removeObject(forKey: customRefreshUrlKey)
         defaults.removeObject(forKey: syncActiveKey)
         defaults.removeObject(forKey: trackedTypesKey)
         defaults.removeObject(forKey: syncDaysBackKey)

--- a/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
+++ b/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
@@ -203,18 +203,29 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
     
     /// Initialize the SDK with the backend host URL.
     /// This also restores previously tracked types and auto-resumes sync if it was active.
-    public func configure(host: String) {
+    ///
+    /// - Parameters:
+    ///   - host: Base host for the data-sync API (`{host}/api/v1/...`).
+    ///   - tokenRefreshURL: Optional absolute URL used to refresh the access
+    ///     token. When `nil`, the SDK refreshes against `{host}/api/v1/token/refresh`.
+    ///     Set this when your auth/mint server is separate from the sync host —
+    ///     the SDK posts `{"refresh_token": ...}` and expects
+    ///     `{"access_token": ..., "refresh_token": ...}` back. The value is
+    ///     persisted so background refresh tasks use it too.
+    public func configure(host: String, tokenRefreshURL: String? = nil) {
         OpenWearablesHealthSdkKeychain.clearKeychainIfReinstalled()
-        
+
         self.host = host
         OpenWearablesHealthSdkKeychain.saveHost(host)
-        
+        OpenWearablesHealthSdkKeychain.saveCustomRefreshUrl(tokenRefreshURL)
+
         if let storedTypes = OpenWearablesHealthSdkKeychain.getTrackedTypes() {
             self.trackedTypes = mapTypesFromStrings(storedTypes)
             logMessage("Restored \(trackedTypes.count) tracked types")
         }
-        
-        logMessage("Configured: host=\(host)")
+
+        let refreshTarget = tokenRefreshURL ?? "{host}/api/v1/token/refresh (default)"
+        logMessage("Configured: host=\(host), tokenRefreshURL=\(refreshTarget)")
         
         if OpenWearablesHealthSdkKeychain.isSyncActive() && OpenWearablesHealthSdkKeychain.hasSession() && !trackedTypes.isEmpty {
             logMessage("Auto-restoring background sync...")
@@ -1146,23 +1157,35 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
             return
         }
         
-        guard let refreshToken = self.refreshToken, let base = self.apiBaseUrl else {
+        // Resolve the refresh endpoint: an explicit override (configure
+        // tokenRefreshURL:) wins, otherwise default to "{apiBaseUrl}/token/refresh".
+        // This lets deployments whose auth/mint server differs from the data-sync
+        // host refresh against the correct URL — including from the background
+        // refresh task, which reads the persisted override (see axl-app#39).
+        let resolvedRefreshUrl: String? = {
+            if let custom = OpenWearablesHealthSdkKeychain.getCustomRefreshUrl(),
+               !custom.isEmpty {
+                return custom
+            }
+            if let base = self.apiBaseUrl {
+                return "\(base)/token/refresh"
+            }
+            return nil
+        }()
+
+        guard let refreshToken = self.refreshToken,
+              let refreshUrlString = resolvedRefreshUrl,
+              let url = URL(string: refreshUrlString) else {
             tokenRefreshLock.unlock()
-            logMessage("Token refresh failed: no credentials")
+            logMessage("Token refresh failed: no credentials or refresh URL")
             completion(.authFailure)
             return
         }
-        
+
         isRefreshingToken = true
         tokenRefreshCallbacks.append(completion)
         tokenRefreshLock.unlock()
-        
-        guard let url = URL(string: "\(base)/token/refresh") else {
-            logMessage("Token refresh failed: invalid URL")
-            finishTokenRefresh(result: .authFailure)
-            return
-        }
-        
+
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Tests/OpenWearablesHealthSDKTests/OpenWearablesHealthSDKTests.swift
+++ b/Tests/OpenWearablesHealthSDKTests/OpenWearablesHealthSDKTests.swift
@@ -31,4 +31,29 @@ final class OpenWearablesHealthSDKTests: XCTestCase {
         XCTAssertNotNil(status["completedTypes"])
         XCTAssertNotNil(status["isFullExport"])
     }
+
+    func testConfigureWithTokenRefreshURLPersistsOverride() {
+        let sdk = OpenWearablesHealthSDK.shared
+        let refreshURL = "https://auth.example.com/v1/wearables/session"
+        sdk.configure(host: "https://sync.example.com", tokenRefreshURL: refreshURL)
+        XCTAssertEqual(
+            OpenWearablesHealthSdkKeychain.getCustomRefreshUrl(),
+            refreshURL,
+            "configure(tokenRefreshURL:) should persist the override for background refresh"
+        )
+    }
+
+    func testConfigureWithoutTokenRefreshURLClearsOverride() {
+        let sdk = OpenWearablesHealthSDK.shared
+        // Set an override first...
+        sdk.configure(
+            host: "https://sync.example.com",
+            tokenRefreshURL: "https://auth.example.com/refresh"
+        )
+        XCTAssertNotNil(OpenWearablesHealthSdkKeychain.getCustomRefreshUrl())
+        // ...a plain configure clears it so the SDK falls back to the default
+        // "{host}/api/v1/token/refresh" endpoint.
+        sdk.configure(host: "https://sync.example.com")
+        XCTAssertNil(OpenWearablesHealthSdkKeychain.getCustomRefreshUrl())
+    }
 }


### PR DESCRIPTION
## Problem

The SDK refreshes the access token against a URL hardcoded to the **data-sync host**:

```swift
URL(string: "\(apiBaseUrl)/token/refresh")   // apiBaseUrl = "{host}/api/v1"
```

This assumes the auth/mint server and the resource (sync) server are the same host. In deployments where they're separate — a very common **auth-server ≠ resource-server** split — the refresh hits the wrong host and fails. Once the short-lived access token expires, every background sync then returns `401` until the app is reopened, producing recurring 401 storms.

## Change

Make the token-refresh endpoint configurable, fully backward compatible:

- `configure(host:tokenRefreshURL:)` gains an optional `tokenRefreshURL`.
  - When set, the SDK refreshes against that absolute URL.
  - When omitted (`nil`), behavior is unchanged: it uses `"{host}/api/v1/token/refresh"`.
- The override is persisted in the shared `UserDefaults` suite, so the **background refresh `BGTask`** (which runs in a fresh process) reads it too — this is what actually fixes background 401s.
- The request/response **contract is unchanged**: `POST { "refresh_token": ... }` → `{ "access_token": ..., "refresh_token": ... }`.

## Tests

Adds unit tests covering that `configure(tokenRefreshURL:)` persists the override and that a plain `configure(host:)` clears it (falls back to the default endpoint). Full suite green on iOS Simulator (`xcodebuild test`).

## Notes

- No API break — existing callers compile and behave identically.
- The Android / React Native SDKs hardcode the same `/token/refresh`; happy to mirror this there if useful.
