### PR TITLE
Restore persisted host on init so background token refresh works

### DIFF
--- a/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
+++ b/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
@@ -171,10 +171,7 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
     private override init() {
         super.init()
 
-        // Host is persisted by configure() but previously only lived in memory at
-        // runtime. Restore it immediately so background relaunches (URLSession /
-        // BGTask) can build apiBaseUrl and refresh tokens before the host app
-        // calls configure(host:) again. See the-momentum/open_wearables_ios_sdk#18.
+        // Restore host from persistence (needed before configure() on background relaunch)
         restorePersistedHostIfNeeded()
         
         let bgCfg = URLSessionConfiguration.background(withIdentifier: bgSessionId)
@@ -205,17 +202,14 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         bgCompletionHandler = handler
     }
     
-    // MARK: - Host restore
-
-    /// Loads `host` from persistence when the in-memory value is nil.
-    /// Safe to call repeatedly; no-ops when `host` is already set.
+    /// Restore `host` from persistence when it is not already set in memory.
     internal func restorePersistedHostIfNeeded() {
         guard host == nil else { return }
         if let persisted = OpenWearablesHealthSdkKeychain.getHost(), !persisted.isEmpty {
             host = persisted
         }
     }
-
+    
     // MARK: - Public API: Configure
     
     /// Initialize the SDK with the backend host URL.

--- a/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
+++ b/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
@@ -170,6 +170,12 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
     
     private override init() {
         super.init()
+
+        // Host is persisted by configure() but previously only lived in memory at
+        // runtime. Restore it immediately so background relaunches (URLSession /
+        // BGTask) can build apiBaseUrl and refresh tokens before the host app
+        // calls configure(host:) again. See the-momentum/open_wearables_ios_sdk#18.
+        restorePersistedHostIfNeeded()
         
         let bgCfg = URLSessionConfiguration.background(withIdentifier: bgSessionId)
         bgCfg.isDiscretionary = false
@@ -199,6 +205,17 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         bgCompletionHandler = handler
     }
     
+    // MARK: - Host restore
+
+    /// Loads `host` from persistence when the in-memory value is nil.
+    /// Safe to call repeatedly; no-ops when `host` is already set.
+    internal func restorePersistedHostIfNeeded() {
+        guard host == nil else { return }
+        if let persisted = OpenWearablesHealthSdkKeychain.getHost(), !persisted.isEmpty {
+            host = persisted
+        }
+    }
+
     // MARK: - Public API: Configure
     
     /// Initialize the SDK with the backend host URL.

--- a/Tests/OpenWearablesHealthSDKTests/OpenWearablesHealthSDKTests.swift
+++ b/Tests/OpenWearablesHealthSDKTests/OpenWearablesHealthSDKTests.swift
@@ -34,23 +34,33 @@ final class OpenWearablesHealthSDKTests: XCTestCase {
     
     func testRestorePersistedHostWhenMemoryNil() {
         let sdk = OpenWearablesHealthSDK.shared
-        sdk.configure(host: "https://restore-test.example.com")
+        OpenWearablesHealthSdkKeychain.saveHost("https://restore-test.example.com")
         sdk.host = nil
         XCTAssertNil(sdk.host)
-        
+
         sdk.restorePersistedHostIfNeeded()
-        
+
         XCTAssertEqual(sdk.host, "https://restore-test.example.com")
         XCTAssertEqual(sdk.apiBaseUrl, "https://restore-test.example.com/api/v1")
+
+        restoreHostState()
     }
-    
+
     func testRestorePersistedHostDoesNotOverwriteMemory() {
         let sdk = OpenWearablesHealthSDK.shared
-        sdk.configure(host: "https://persisted.example.com")
+        OpenWearablesHealthSdkKeychain.saveHost("https://persisted.example.com")
         sdk.host = "https://in-memory.example.com"
-        
+
         sdk.restorePersistedHostIfNeeded()
-        
+
         XCTAssertEqual(sdk.host, "https://in-memory.example.com")
+
+        restoreHostState()
+    }
+
+    /// Undo host mutations on the shared singleton and persisted store so other tests are unaffected.
+    private func restoreHostState() {
+        OpenWearablesHealthSdkKeychain.saveHost(nil)
+        OpenWearablesHealthSDK.shared.host = nil
     }
 }

--- a/Tests/OpenWearablesHealthSDKTests/OpenWearablesHealthSDKTests.swift
+++ b/Tests/OpenWearablesHealthSDKTests/OpenWearablesHealthSDKTests.swift
@@ -32,3 +32,27 @@ final class OpenWearablesHealthSDKTests: XCTestCase {
         XCTAssertNotNil(status["isFullExport"])
     }
 }
+
+
+    func testRestorePersistedHostIfNeededLoadsHostWhenMemoryNil() {
+        let sdk = OpenWearablesHealthSDK.shared
+        sdk.configure(host: "https://restore-test.example.com")
+        sdk.host = nil
+        XCTAssertNil(sdk.host)
+
+        sdk.restorePersistedHostIfNeeded()
+
+        XCTAssertEqual(sdk.host, "https://restore-test.example.com")
+        XCTAssertEqual(sdk.apiBaseUrl, "https://restore-test.example.com/api/v1")
+    }
+
+    func testRestorePersistedHostIfNeededDoesNotOverwriteInMemoryHost() {
+        let sdk = OpenWearablesHealthSDK.shared
+        sdk.configure(host: "https://persisted.example.com")
+        sdk.host = "https://in-memory.example.com"
+
+        sdk.restorePersistedHostIfNeeded()
+
+        XCTAssertEqual(sdk.host, "https://in-memory.example.com")
+    }
+

--- a/Tests/OpenWearablesHealthSDKTests/OpenWearablesHealthSDKTests.swift
+++ b/Tests/OpenWearablesHealthSDKTests/OpenWearablesHealthSDKTests.swift
@@ -31,8 +31,6 @@ final class OpenWearablesHealthSDKTests: XCTestCase {
         XCTAssertNotNil(status["completedTypes"])
         XCTAssertNotNil(status["isFullExport"])
     }
-}
-
 
     func testRestorePersistedHostIfNeededLoadsHostWhenMemoryNil() {
         let sdk = OpenWearablesHealthSDK.shared
@@ -55,4 +53,4 @@ final class OpenWearablesHealthSDKTests: XCTestCase {
 
         XCTAssertEqual(sdk.host, "https://in-memory.example.com")
     }
-
+}

--- a/Tests/OpenWearablesHealthSDKTests/OpenWearablesHealthSDKTests.swift
+++ b/Tests/OpenWearablesHealthSDKTests/OpenWearablesHealthSDKTests.swift
@@ -31,26 +31,26 @@ final class OpenWearablesHealthSDKTests: XCTestCase {
         XCTAssertNotNil(status["completedTypes"])
         XCTAssertNotNil(status["isFullExport"])
     }
-
-    func testRestorePersistedHostIfNeededLoadsHostWhenMemoryNil() {
+    
+    func testRestorePersistedHostWhenMemoryNil() {
         let sdk = OpenWearablesHealthSDK.shared
         sdk.configure(host: "https://restore-test.example.com")
         sdk.host = nil
         XCTAssertNil(sdk.host)
-
+        
         sdk.restorePersistedHostIfNeeded()
-
+        
         XCTAssertEqual(sdk.host, "https://restore-test.example.com")
         XCTAssertEqual(sdk.apiBaseUrl, "https://restore-test.example.com/api/v1")
     }
-
-    func testRestorePersistedHostIfNeededDoesNotOverwriteInMemoryHost() {
+    
+    func testRestorePersistedHostDoesNotOverwriteMemory() {
         let sdk = OpenWearablesHealthSDK.shared
         sdk.configure(host: "https://persisted.example.com")
         sdk.host = "https://in-memory.example.com"
-
+        
         sdk.restorePersistedHostIfNeeded()
-
+        
         XCTAssertEqual(sdk.host, "https://in-memory.example.com")
     }
 }


### PR DESCRIPTION
## Summary
- Restore the host persisted by `configure()` (`OpenWearablesHealthSdkKeychain.getHost()`) during SDK `init`, so background relaunches have `apiBaseUrl` before the host app calls `configure(host:)` again.
- Add `restorePersistedHostIfNeeded()` (idempotent; does not overwrite an in-memory host) and unit coverage. Tests persist the host directly via the keychain helper and reset both the persisted and in-memory host afterwards, so they do not leak state into the rest of the suite.

Fixes #18

## Test plan
- [x] `restorePersistedHostIfNeeded` loads host when memory is nil (suite passes on iPhone 17 Pro simulator, 6/6)
- [x] Does not overwrite an already-set in-memory host
- [ ] Manual: sign in, let access token expire, force-quit, trigger HealthKit background delivery - expect `POST /api/v1/token/refresh` and successful sync without opening the app

Made with [Cursor](https://cursor.com)
