### PR TITLE
Map HKCategoryValueSleepAnalysis.asleepCore to "core", not "light"

### DIFF
--- a/Sources/OpenWearablesHealthSDK/Internal/Types.swift
+++ b/Sources/OpenWearablesHealthSDK/Internal/Types.swift
@@ -923,12 +923,17 @@ extension OpenWearablesHealthSDK {
     
     // MARK: - Sleep stage mapping
     
+    /// Maps HKCategoryValueSleepAnalysis raw values to stage strings.
+    /// Raw value 3 is `.asleepCore` — Apple's own name for the stage — so it
+    /// must serialize as "core". It previously emitted "light", which callers
+    /// could not distinguish from an undifferentiated asleep sample, causing
+    /// core sleep to be dropped from total-sleep aggregations.
     private func _sleepStageString(_ value: Int) -> String {
         switch value {
         case 0: return "in_bed"
         case 1: return "sleeping"
         case 2: return "awake"
-        case 3: return "light"
+        case 3: return "core"
         case 4: return "deep"
         case 5: return "rem"
         default: return "unknown"


### PR DESCRIPTION
Raw value `3` of `HKCategoryValueSleepAnalysis` is `.asleepCore`. `_sleepStageString` currently emits `"light"` for it, which is not one of Apple's stage names.

## Why this matters downstream

Consumers that prefer detailed stages (`core`/`deep`/`rem`) over an undifferentiated asleep bucket cannot tell `"light"` apart from a generic asleep sample, so they fall back to treating it as generic. An aggregator written as:

```
const detailed = rows.filter(r => ["core","deep","rem"].includes(r.stage));
return detailed.length ? detailed : rows.filter(r => r.stage === "asleep");
```

keeps only deep + REM once any detailed stage is present, and silently drops every core interval.

The observable result is that total sleep duration equals `deep + rem` exactly. On real nights that is roughly half of actual sleep — e.g. a measured 7h44m in bed reported as 3h47m asleep, with sleep efficiency correspondingly halved.

## The change

One line in `Sources/OpenWearablesHealthSDK/Internal/Types.swift`, plus a doc comment:

```diff
-        case 3: return "light"
+        case 3: return "core"
```

`deep` (4) and `rem` (5) already match Apple's naming; this makes 3 consistent with them.

## Compatibility note

Any consumer currently special-casing the `"light"` string will need to accept `"core"`. Given `"light"` does not correspond to a HealthKit stage name, we judged aligning with Apple to be the correct fix rather than preserving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)