### PR TITLE
fix: prevent sync loop, anchor loss and background upload

### DIFF
--- a/.idea/caches/deviceStreaming.xml
+++ b/.idea/caches/deviceStreaming.xml
@@ -10,7 +10,7 @@
           <option name="id" value="A402SO" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Sony" />
-          <option name="name" value="Xperia 10" />
+          <option name="name" value="Xperia 10 VI" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2520" />
@@ -28,13 +28,25 @@
           <option name="screenY" value="1280" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="Infinix" />
+          <option name="codename" value="Infinix-X6525" />
+          <option name="id" value="Infinix-X6525" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="INFINIX MOBILITY LIMITED" />
+          <option name="name" value="Infinix SMART 8" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1612" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="OnePlus" />
           <option name="codename" value="OP535DL1" />
           <option name="id" value="OP535DL1" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="OnePlus" />
-          <option name="name" value="CPH2409" />
+          <option name="name" value="Nord CE 2 Lite 5G" />
           <option name="screenDensity" value="401" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2412" />
@@ -46,7 +58,7 @@
           <option name="id" value="OP5552L1" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="OnePlus" />
-          <option name="name" value="CPH2415" />
+          <option name="name" value="10T 5G" />
           <option name="screenDensity" value="480" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2412" />
@@ -58,10 +70,94 @@
           <option name="id" value="OP573DL1" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="OPPO" />
-          <option name="name" value="CPH2557" />
+          <option name="name" value="A79 5G" />
           <option name="screenDensity" value="480" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="OPPO" />
+          <option name="codename" value="OP5759L1" />
+          <option name="id" value="OP5759L1" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="OPPO" />
+          <option name="name" value="A38" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1612" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="realme" />
+          <option name="codename" value="RE58C2" />
+          <option name="id" value="RE58C2" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="realme" />
+          <option name="name" value="C53" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="30" />
+          <option name="brand" value="realme" />
+          <option name="codename" value="RMX3231" />
+          <option name="id" value="RMX3231" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="realme" />
+          <option name="name" value="RMX3231" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="SC-51C" />
+          <option name="id" value="SC-51C" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S22" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="SC-51E" />
+          <option name="id" value="SC-51E" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S24" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="SC-53C" />
+          <option name="id" value="SC-53C" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A53 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="SCG13" />
+          <option name="id" value="SCG13" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S22" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="28" />
@@ -76,17 +172,52 @@
           <option name="screenY" value="2160" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
-          <option name="api" value="35" />
-          <option name="brand" value="Lenovo" />
-          <option name="codename" value="TB330FU" />
-          <option name="formFactor" value="Tablet" />
-          <option name="id" value="TB330FU" />
+          <option name="api" value="31" />
+          <option name="brand" value="TECNO" />
+          <option name="codename" value="TECNO-BF6" />
+          <option name="id" value="TECNO-BF6" />
           <option name="labId" value="google" />
-          <option name="manufacturer" value="Lenovo" />
-          <option name="name" value="Tab M11" />
-          <option name="screenDensity" value="240" />
-          <option name="screenX" value="1200" />
-          <option name="screenY" value="1920" />
+          <option name="manufacturer" value="TECNO" />
+          <option name="name" value="POP 7" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1612" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="31" />
+          <option name="brand" value="TECNO" />
+          <option name="codename" value="TECNO-BF7" />
+          <option name="id" value="TECNO-BF7" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="TECNO" />
+          <option name="name" value="TECNO" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1612" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="TECNO" />
+          <option name="codename" value="TECNO-BG6" />
+          <option name="id" value="TECNO-BG6" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="TECNO MOBILE LIMITED" />
+          <option name="name" value="SPARK Go 2024" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1612" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="31" />
+          <option name="brand" value="TECNO" />
+          <option name="codename" value="TECNO-KI5k" />
+          <option name="id" value="TECNO-KI5k" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="TECNO" />
+          <option name="name" value="SPARK 10C" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1612" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="33" />
@@ -101,13 +232,37 @@
           <option name="screenY" value="1600" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a03sutfn" />
+          <option name="id" value="a03sutfn" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A03s" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a04s" />
+          <option name="id" value="a04s" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A04s" />
+          <option name="screenDensity" value="300" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="35" />
           <option name="brand" value="samsung" />
           <option name="codename" value="a05s" />
           <option name="id" value="a05s" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="A05s" />
+          <option name="name" value="Galaxy A05s" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
@@ -137,13 +292,25 @@
           <option name="screenY" value="2408" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a13x" />
+          <option name="id" value="a13x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A13 5G" />
+          <option name="screenDensity" value="300" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="a14m" />
           <option name="id" value="a14m" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-A145R" />
+          <option name="name" value="Galaxy A14" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2408" />
@@ -179,7 +346,7 @@
           <option name="id" value="a15" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="A15" />
+          <option name="name" value="Galaxy A15" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -191,7 +358,7 @@
           <option name="id" value="a15x" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="A15 5G" />
+          <option name="name" value="Galaxy A15 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -203,7 +370,19 @@
           <option name="id" value="a15x" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="A15 5G" />
+          <option name="name" value="Galaxy A15 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a15xtfn" />
+          <option name="id" value="a15xtfn" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A15 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -215,7 +394,7 @@
           <option name="id" value="a16" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-A165M" />
+          <option name="name" value="Galaxy A16" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -227,7 +406,7 @@
           <option name="id" value="a16x" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="A16 5G" />
+          <option name="name" value="Galaxy A16 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -239,7 +418,19 @@
           <option name="id" value="a16x" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="A16 5G" />
+          <option name="name" value="Galaxy A16 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a16xeea" />
+          <option name="id" value="a16xeea" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A16 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -257,16 +448,52 @@
           <option name="screenY" value="1600" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a23xq" />
+          <option name="id" value="a23xq" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A23 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2408" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="36" />
           <option name="brand" value="samsung" />
           <option name="codename" value="a26x" />
           <option name="id" value="a26x" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-A266B" />
+          <option name="name" value="Galaxy A26 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="31" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a31" />
+          <option name="id" value="a31" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A31" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a32" />
+          <option name="id" value="a32" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A32" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="36" />
@@ -275,7 +502,7 @@
           <option name="id" value="a34x" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-A346N" />
+          <option name="name" value="Galaxy A34 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -287,7 +514,7 @@
           <option name="id" value="a35x" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="A35" />
+          <option name="name" value="Galaxy A35 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -299,7 +526,7 @@
           <option name="id" value="a35x" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="A35" />
+          <option name="name" value="Galaxy A35 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -311,7 +538,7 @@
           <option name="id" value="a35x" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="A35" />
+          <option name="name" value="Galaxy A35 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -323,7 +550,7 @@
           <option name="id" value="a36xq" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-A366E" />
+          <option name="name" value="Galaxy A36 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -335,7 +562,43 @@
           <option name="id" value="a36xq" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-A366E" />
+          <option name="name" value="Galaxy A36 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a52xq" />
+          <option name="id" value="a52xq" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A52 5G" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a54xue" />
+          <option name="id" value="a54xue" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A54 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a55xzh" />
+          <option name="id" value="a55xzh" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A55 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -347,7 +610,7 @@
           <option name="id" value="a56x" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-A566E" />
+          <option name="name" value="Galaxy A56 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -389,6 +652,18 @@
           <option name="screenY" value="1272" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="30" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="aruba" />
+          <option name="id" value="aruba" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto e20" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="33" />
           <option name="brand" value="motorola" />
           <option name="codename" value="austin" />
@@ -425,14 +700,98 @@
           <option name="screenY" value="3088" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b0qksx" />
+          <option name="id" value="b0qksx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S22 Ultra" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2316" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b0qxxx" />
+          <option name="id" value="b0qxxx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S22 Ultra" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2316" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b4qsqw" />
+          <option name="id" value="b4qsqw" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Flip4" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2640" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b5qsqw" />
+          <option name="id" value="b5qsqw" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Flip5" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="748" />
+          <option name="screenY" value="720" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b5qxeea" />
+          <option name="id" value="b5qxeea" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Flip5" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="748" />
+          <option name="screenY" value="720" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="b6q" />
           <option name="id" value="b6q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy Z Flip 6" />
+          <option name="name" value="Galaxy Z Flip6" />
           <option name="screenDensity" value="340" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2640" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b6qksx" />
+          <option name="id" value="b6qksx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Flip6" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2640" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b6qsqw" />
+          <option name="id" value="b6qsqw" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Flip6" />
+          <option name="screenDensity" value="480" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2640" />
         </PersistentDeviceSelectionData>
@@ -440,6 +799,7 @@
           <option name="api" value="36" />
           <option name="brand" value="google" />
           <option name="codename" value="blazer" />
+          <option name="default" value="true" />
           <option name="id" value="blazer" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
@@ -467,10 +827,58 @@
           <option name="id" value="c1q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy Note 20 5G" />
+          <option name="name" value="Galaxy Note20 5G" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="c1qksw" />
+          <option name="id" value="c1qksw" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Note20 5G" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="c2q" />
+          <option name="id" value="c2q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Note20 Ultra 5G" />
+          <option name="screenDensity" value="560" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3088" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="c2qksw" />
+          <option name="id" value="c2qksw" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Note20 Ultra 5G" />
+          <option name="screenDensity" value="560" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3088" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="c2s" />
+          <option name="id" value="c2s" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Note20 Ultra 5G" />
+          <option name="screenDensity" value="560" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3088" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
@@ -498,9 +906,20 @@
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="cancun" />
+          <option name="id" value="cancun" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g14" />
+          <option name="screenDensity" value="400" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
           <option name="brand" value="google" />
           <option name="codename" value="comet" />
-          <option name="default" value="true" />
           <option name="id" value="comet" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
@@ -513,7 +932,18 @@
           <option name="api" value="35" />
           <option name="brand" value="google" />
           <option name="codename" value="comet" />
-          <option name="default" value="true" />
+          <option name="id" value="comet" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro Fold" />
+          <option name="screenDensity" value="390" />
+          <option name="screenX" value="2076" />
+          <option name="screenY" value="2152" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="google" />
+          <option name="codename" value="comet" />
           <option name="id" value="comet" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
@@ -529,7 +959,7 @@
           <option name="id" value="cuscoi" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
-          <option name="name" value="edge 50 fusion" />
+          <option name="name" value="moto g96 5G" />
           <option name="screenDensity" value="400" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
@@ -541,7 +971,7 @@
           <option name="id" value="dm1q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="S23" />
+          <option name="name" value="Galaxy S23" />
           <option name="screenDensity" value="480" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -553,7 +983,7 @@
           <option name="id" value="dm1q-SM-S911U" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="S23" />
+          <option name="name" value="Galaxy S23" />
           <option name="screenDensity" value="480" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -577,7 +1007,19 @@
           <option name="id" value="dm2q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="S23 Plus" />
+          <option name="name" value="Galaxy S23+" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="dm2qksx" />
+          <option name="id" value="dm2qksx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S23+" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -610,7 +1052,6 @@
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="e1q" />
-          <option name="default" value="true" />
           <option name="id" value="e1q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
@@ -623,8 +1064,19 @@
           <option name="api" value="36" />
           <option name="brand" value="samsung" />
           <option name="codename" value="e1q" />
-          <option name="default" value="true" />
           <option name="id" value="e1q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S24" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="e1s" />
+          <option name="id" value="e1s" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy S24" />
@@ -639,7 +1091,7 @@
           <option name="id" value="e2q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S24 +" />
+          <option name="name" value="Galaxy S24+" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -649,6 +1101,18 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="e2s" />
           <option name="id" value="e2s" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S24+" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="e2sksx" />
+          <option name="id" value="e2sksx" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy S24+" />
@@ -741,6 +1205,18 @@
           <option name="screenY" value="1840" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="google" />
+          <option name="codename" value="felix" />
+          <option name="id" value="felix" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Fold" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="2208" />
+          <option name="screenY" value="1840" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="33" />
           <option name="brand" value="google" />
           <option name="codename" value="felix_camera" />
@@ -792,6 +1268,7 @@
           <option name="api" value="36" />
           <option name="brand" value="google" />
           <option name="codename" value="frankel" />
+          <option name="default" value="true" />
           <option name="id" value="frankel" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
@@ -807,7 +1284,7 @@
           <option name="id" value="g0q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-S906U1" />
+          <option name="name" value="Galaxy S22+" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -819,7 +1296,19 @@
           <option name="id" value="g0q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-S906U1" />
+          <option name="name" value="Galaxy S22+" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="g0qksx" />
+          <option name="id" value="g0qksx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S22+" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -837,16 +1326,41 @@
           <option name="screenY" value="1600" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="31" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gta4lwifi" />
+          <option name="id" value="gta4lwifi" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Tab A7" />
+          <option name="screenDensity" value="240" />
+          <option name="screenX" value="1200" />
+          <option name="screenY" value="2000" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="gta9pwifi" />
           <option name="id" value="gta9pwifi" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-X210" />
+          <option name="name" value="Galaxy Tab A9+" />
           <option name="screenDensity" value="240" />
           <option name="screenX" value="1200" />
           <option name="screenY" value="1920" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts10pwifi" />
+          <option name="formFactor" value="Tablet" />
+          <option name="id" value="gts10pwifi" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Tab S10+" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="1752" />
+          <option name="screenY" value="2800" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="33" />
@@ -855,7 +1369,7 @@
           <option name="id" value="gts7lwifi" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-T870" />
+          <option name="name" value="Galaxy Tab S7" />
           <option name="screenDensity" value="340" />
           <option name="screenX" value="1600" />
           <option name="screenY" value="2560" />
@@ -867,10 +1381,22 @@
           <option name="id" value="gts7xllite" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-T738U" />
+          <option name="name" value="Galaxy Tab S7 FE 5G" />
           <option name="screenDensity" value="340" />
           <option name="screenX" value="1600" />
           <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts7xlwifi" />
+          <option name="id" value="gts7xlwifi" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Tab S7+" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1752" />
+          <option name="screenY" value="2800" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="33" />
@@ -917,10 +1443,34 @@
           <option name="id" value="gts9wifi" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-X710" />
+          <option name="name" value="Galaxy Tab S9" />
           <option name="screenDensity" value="340" />
           <option name="screenX" value="1600" />
           <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="30" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="guamna" />
+          <option name="id" value="guamna" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g play (2021)" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="30" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="guamp" />
+          <option name="id" value="guamp" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g(9) play" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
@@ -1043,6 +1593,42 @@
           <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="m1q" />
+          <option name="id" value="m1q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S26" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="m2q" />
+          <option name="id" value="m2q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S26+" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="malmo" />
+          <option name="id" value="malmo" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g85 5G" />
+          <option name="screenDensity" value="400" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="motorola" />
           <option name="codename" value="manaus" />
@@ -1070,6 +1656,7 @@
           <option name="api" value="36" />
           <option name="brand" value="google" />
           <option name="codename" value="mustang" />
+          <option name="default" value="true" />
           <option name="id" value="mustang" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
@@ -1085,7 +1672,7 @@
           <option name="id" value="o1q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S21" />
+          <option name="name" value="Galaxy S21 5G" />
           <option name="screenDensity" value="421" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
@@ -1097,8 +1684,20 @@
           <option name="id" value="o1q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S21" />
+          <option name="name" value="Galaxy S21 5G" />
           <option name="screenDensity" value="421" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="o1s" />
+          <option name="id" value="o1s" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S21 5G" />
+          <option name="screenDensity" value="480" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
@@ -1121,10 +1720,34 @@
           <option name="id" value="p3q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S21 Ultra" />
+          <option name="name" value="Galaxy S21 Ultra 5G" />
           <option name="screenDensity" value="600" />
           <option name="screenX" value="1440" />
           <option name="screenY" value="3200" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="p3s" />
+          <option name="id" value="p3s" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S21 Ultra 5G" />
+          <option name="screenDensity" value="600" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3200" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="pa1qksx" />
+          <option name="id" value="pa1qksx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S25" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="36" />
@@ -1133,7 +1756,7 @@
           <option name="id" value="pa2q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="S25+" />
+          <option name="name" value="Galaxy S25+" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -1163,18 +1786,6 @@
           <option name="screenY" value="2340" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
-          <option name="api" value="36" />
-          <option name="brand" value="samsung" />
-          <option name="codename" value="pa3q" />
-          <option name="id" value="pa3q" />
-          <option name="labId" value="google" />
-          <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S25 Ultra" />
-          <option name="screenDensity" value="450" />
-          <option name="screenX" value="1080" />
-          <option name="screenY" value="2340" />
-        </PersistentDeviceSelectionData>
-        <PersistentDeviceSelectionData>
           <option name="api" value="33" />
           <option name="brand" value="google" />
           <option name="codename" value="panther" />
@@ -1185,6 +1796,18 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="penang" />
+          <option name="id" value="penang" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g53 5G" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="35" />
@@ -1199,10 +1822,46 @@
           <option name="screenY" value="3120" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="q2qsqw" />
+          <option name="id" value="q2qsqw" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Fold3 5G" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="832" />
+          <option name="screenY" value="2268" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="q4qksx" />
+          <option name="id" value="q4qksx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Fold4" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1812" />
+          <option name="screenY" value="2176" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="q5q" />
           <option name="id" value="q5q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Fold5" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1812" />
+          <option name="screenY" value="2176" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="q5qksx" />
+          <option name="id" value="q5qksx" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy Z Fold5" />
@@ -1225,11 +1884,71 @@
         <PersistentDeviceSelectionData>
           <option name="api" value="36" />
           <option name="brand" value="samsung" />
+          <option name="codename" value="q6qksx" />
+          <option name="id" value="q6qksx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Fold6" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1856" />
+          <option name="screenY" value="2160" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="q6qsqw" />
+          <option name="id" value="q6qsqw" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Fold6" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1856" />
+          <option name="screenY" value="2160" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="q7mq" />
+          <option name="id" value="q7mq" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z TriFold" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="2160" />
+          <option name="screenY" value="1584" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="r0q" />
+          <option name="id" value="r0q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S22" />
+          <option name="screenDensity" value="425" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
           <option name="codename" value="r0qcsx" />
           <option name="id" value="r0qcsx" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="S22" />
+          <option name="name" value="Galaxy S22" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="r0qksx" />
+          <option name="id" value="r0qksx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S22" />
           <option name="screenDensity" value="480" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -1255,7 +1974,19 @@
           <option name="id" value="r11q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-S711U" />
+          <option name="name" value="Galaxy S23 FE" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="r11qcs" />
+          <option name="id" value="r11qcs" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S23 FE" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -1267,7 +1998,7 @@
           <option name="id" value="r11s" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-S711N" />
+          <option name="name" value="Galaxy S23 FE" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -1277,6 +2008,30 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="r8q" />
           <option name="id" value="r8q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S20 FE 5G" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="r8qcsx" />
+          <option name="id" value="r8qcsx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S20 FE 5G" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="r8qksx" />
+          <option name="id" value="r8qksx" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy S20 FE 5G" />
@@ -1310,8 +2065,21 @@
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="r9q2csx" />
+          <option name="id" value="r9q2csx" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S21 FE 5G" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
           <option name="brand" value="google" />
           <option name="codename" value="rango" />
+          <option name="default" value="true" />
           <option name="id" value="rango" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
@@ -1345,13 +2113,25 @@
           <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="google" />
+          <option name="codename" value="shiba" />
+          <option name="id" value="shiba" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 8" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="t2q" />
           <option name="id" value="t2q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S21 Plus" />
+          <option name="name" value="Galaxy S21+ 5G" />
           <option name="screenDensity" value="394" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
@@ -1363,13 +2143,26 @@
           <option name="id" value="t2q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S21 Plus" />
+          <option name="name" value="Galaxy S21+ 5G" />
           <option name="screenDensity" value="394" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tangorpro" />
+          <option name="formFactor" value="Tablet" />
+          <option name="id" value="tangorpro" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Tablet" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="1600" />
+          <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
           <option name="brand" value="google" />
           <option name="codename" value="tangorpro" />
           <option name="formFactor" value="Tablet" />
@@ -1397,7 +2190,6 @@
           <option name="api" value="34" />
           <option name="brand" value="google" />
           <option name="codename" value="tokay" />
-          <option name="default" value="true" />
           <option name="id" value="tokay" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
@@ -1410,7 +2202,6 @@
           <option name="api" value="35" />
           <option name="brand" value="google" />
           <option name="codename" value="tokay" />
-          <option name="default" value="true" />
           <option name="id" value="tokay" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
@@ -1423,7 +2214,6 @@
           <option name="api" value="36" />
           <option name="brand" value="google" />
           <option name="codename" value="tokay" />
-          <option name="default" value="true" />
           <option name="id" value="tokay" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
@@ -1439,7 +2229,7 @@
           <option name="id" value="xcover7" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="SM-G556B" />
+          <option name="name" value="Galaxy XCover7" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2408" />
@@ -1451,8 +2241,20 @@
           <option name="id" value="y2q" />
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
-          <option name="name" value="S20 Plus 5G" />
+          <option name="name" value="Galaxy S20+ 5G" />
           <option name="screenDensity" value="600" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3200" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="z3q" />
+          <option name="id" value="z3q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S20 Ultra 5G" />
+          <option name="screenDensity" value="560" />
           <option name="screenX" value="1440" />
           <option name="screenY" value="3200" />
         </PersistentDeviceSelectionData>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.14.0
+
+* **Fixed full export poisoning**: when the first upload of a full export failed (offline, backend down, app killed), subsequent triggers overwrote the session as incremental without anchors — causing an infinite re-upload loop of old data. Full-export mode is now sticky until completed; already-poisoned devices self-heal.
+* **Fixed anchor loss on capture errors**: anchor capture silently swallowed errors (e.g. locked device) and ignored deleted objects in pagination, marking types as complete with a missing/stale anchor. Errors now pause sync; deleted objects count toward query limits.
+* **Hardened outbox retries**: retries moved from parallel foreground requests to a serialized background `URLSession` (survives app kill, 1 connection per host). Payloads are preserved on transient failures, dropped on 4xx, expired after 7 days.
+* **Background time management**: sync pauses before background time runs out instead of getting killed mid-upload. New `didBecomeActive` observer resumes sync immediately when the app returns to foreground.
+* **New `getSyncStatus()` fields**: `initialExportDone` (Bool) and `isSyncing` (Bool) — allows apps to show progress UI during the initial historical export.
+* **Removed dead code**: legacy per-type sync path (`syncType`, `enqueueBackgroundUpload`, `chunkSize`).
+
 ## 0.13.0
 
 * **Sync telemetry**: new `/logs` endpoint integration for initial full sync diagnostics.

--- a/README.md
+++ b/README.md
@@ -84,9 +84,6 @@ sdk.requestAuthorization(types: [.steps, .heartRate, .sleep]) { granted in
     }
 }
 
-// Trigger immediate sync
-sdk.syncNow { }
-
 // Stop sync
 sdk.stopBackgroundSync()
 

--- a/Sources/OpenWearablesHealthSDK/Internal/Background.swift
+++ b/Sources/OpenWearablesHealthSDK/Internal/Background.swift
@@ -102,7 +102,8 @@ extension OpenWearablesHealthSDK {
         }
 
         task.expirationHandler = {
-            self.logMessage("BGAppRefresh task expired")
+            self.logMessage("BGAppRefresh task expired - cancelling in-flight uploads")
+            self.cancelInFlightForegroundUploads()
             op.cancel()
         }
         op.completionBlock = { task.setTaskCompleted(success: !op.isCancelled) }
@@ -130,7 +131,8 @@ extension OpenWearablesHealthSDK {
         }
 
         task.expirationHandler = {
-            self.logMessage("BGProcessing task expired")
+            self.logMessage("BGProcessing task expired - cancelling in-flight uploads")
+            self.cancelInFlightForegroundUploads()
             op.cancel()
         }
         op.completionBlock = { task.setTaskCompleted(success: !op.isCancelled) }

--- a/Sources/OpenWearablesHealthSDK/Internal/Outbox.swift
+++ b/Sources/OpenWearablesHealthSDK/Internal/Outbox.swift
@@ -26,60 +26,6 @@ extension OpenWearablesHealthSDK {
         return outboxDir().appendingPathComponent("\(name).\(ext)")
     }
 
-    // MARK: - Background upload with persistence
-    internal func enqueueBackgroundUpload(
-        payload: [String: Any],
-        type: HKSampleType,
-        candidateAnchor: HKQueryAnchor?,
-        endpoint: URL,
-        credential: String,
-        completion: @escaping () -> Void
-    ) {
-        guard let data = try? JSONSerialization.data(withJSONObject: payload) else {
-            completion()
-            return
-        }
-        let id = UUID().uuidString
-        let payloadURL = newPath("payload_\(id)", ext: "json")
-        do {
-            try data.write(to: payloadURL, options: Data.WritingOptions.atomic)
-        } catch {
-            completion()
-            return
-        }
-
-        var anchorURL: URL? = nil
-        if let cand = candidateAnchor,
-           let ad = try? NSKeyedArchiver.archivedData(withRootObject: cand, requiringSecureCoding: true) {
-            let u = newPath("anchor_\(id)", ext: "bin")
-            try? ad.write(to: u, options: Data.WritingOptions.atomic)
-            anchorURL = u
-        }
-
-        let item = OutboxItem(
-            typeIdentifier: type.identifier,
-            userKey: userKey(),
-            payloadPath: payloadURL.path,
-            anchorPath: anchorURL?.path,
-            wasFullExport: nil
-        )
-        let itemURL = newPath("item_\(id)", ext: "json")
-        if let md = try? JSONEncoder().encode(item) {
-            try? md.write(to: itemURL, options: Data.WritingOptions.atomic)
-        }
-
-        var req = URLRequest(url: endpoint)
-        req.httpMethod = "POST"
-        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        applyAuth(to: &req, credential: credential)
-
-        let task = session.uploadTask(with: req, fromFile: payloadURL)
-        task.taskDescription = [itemURL.path, payloadURL.path, anchorURL?.path ?? ""].joined(separator: "|")
-        task.resume()
-
-        completion()
-    }
-    
     // MARK: - Combined upload
     internal func enqueueCombinedUpload(
         payload: [String: Any],
@@ -338,68 +284,106 @@ extension OpenWearablesHealthSDK {
     }
 
     // MARK: - Retry pending items
+    
+    /// Minimum file age before an outbox item is retried (the original upload may
+    /// still be in flight).
+    private static let outboxMinRetryAge: TimeInterval = 30
+    /// Items older than this are dropped - the data is re-fetched from HealthKit by
+    /// the regular sync anyway, so there is no point in re-sending week-old batches.
+    private static let outboxMaxItemAge: TimeInterval = 7 * 24 * 3600
+    
+    /// Retries pending outbox items through the *background* URLSession.
+    /// - uploads go through the background session (survive suspension/kill),
+    /// - the session is limited to one connection per host, so items go out serially,
+    /// - a retry pass is skipped while a regular sync is running,
+    /// - only one retry pass can run at a time,
+    /// - items already enqueued in the background session are not enqueued again.
     internal func retryOutboxIfPossible() {
         guard let endpoint = self.syncEndpoint, let credential = self.authCredential else { return }
-        let dir = outboxDir()
-        guard let files = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) else { return }
         
-        let regularItems = files.filter { $0.lastPathComponent.hasPrefix("item_") && $0.pathExtension == "json" && !$0.lastPathComponent.hasPrefix("combined_item_") }
-        let combinedItems = files.filter { $0.lastPathComponent.hasPrefix("combined_item_") && $0.pathExtension == "json" }
-
-        for itemURL in regularItems {
-            if let attrs = try? FileManager.default.attributesOfItem(atPath: itemURL.path),
-               let mdate = attrs[.modificationDate] as? Date,
-               Date().timeIntervalSince(mdate) < 30 {
-                continue
-            }
-            guard let data = try? Data(contentsOf: itemURL),
-                  let item = try? JSONDecoder().decode(OutboxItem.self, from: data) else { continue }
-            let payloadURL = URL(fileURLWithPath: item.payloadPath)
-            guard FileManager.default.fileExists(atPath: payloadURL.path),
-                  let payloadData = try? Data(contentsOf: payloadURL) else { continue }
-            
-            var req = URLRequest(url: endpoint)
-            req.httpMethod = "POST"
-            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            applyAuth(to: &req, credential: credential)
-            req.httpBody = payloadData
-            req.setValue("\(payloadData.count)", forHTTPHeaderField: "Content-Length")
-
-            let task = foregroundSession.dataTask(with: req) { data, response, error in
-                if let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) {
-                    try? FileManager.default.removeItem(atPath: payloadURL.path)
-                    try? FileManager.default.removeItem(atPath: itemURL.path)
-                }
-            }
-            task.resume()
+        if isSyncInProgress {
+            logMessage("Outbox retry skipped - sync in progress")
+            return
         }
         
-        for itemURL in combinedItems {
-            if let attrs = try? FileManager.default.attributesOfItem(atPath: itemURL.path),
-               let mdate = attrs[.modificationDate] as? Date,
-               Date().timeIntervalSince(mdate) < 30 {
-                continue
+        outboxRetryLock.lock()
+        if isRetryingOutbox {
+            outboxRetryLock.unlock()
+            return
+        }
+        isRetryingOutbox = true
+        outboxRetryLock.unlock()
+        
+        session.getAllTasks { [weak self] tasks in
+            guard let self = self else { return }
+            defer {
+                self.outboxRetryLock.lock()
+                self.isRetryingOutbox = false
+                self.outboxRetryLock.unlock()
             }
-            guard let itemData = try? Data(contentsOf: itemURL),
-                  let item = try? JSONDecoder().decode(OutboxItem.self, from: itemData) else { continue }
-            let payloadURL = URL(fileURLWithPath: item.payloadPath)
-            guard FileManager.default.fileExists(atPath: payloadURL.path),
-                  let payloadData = try? Data(contentsOf: payloadURL) else { continue }
-
-            var req = URLRequest(url: endpoint)
-            req.httpMethod = "POST"
-            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            applyAuth(to: &req, credential: credential)
-            req.httpBody = payloadData
-            req.setValue("\(payloadData.count)", forHTTPHeaderField: "Content-Length")
-
-            let task = foregroundSession.dataTask(with: req) { data, response, error in
-                if let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) {
-                    self.handleSuccessfulUpload(itemPath: itemURL.path, anchorPath: item.anchorPath, wasFullExport: item.wasFullExport ?? false)
-                    try? FileManager.default.removeItem(atPath: payloadURL.path)
+            
+            // Payloads already queued in the background session (possibly from a
+            // previous app run) must not be enqueued a second time.
+            let inFlightPayloadPaths = Set(tasks.compactMap { task -> String? in
+                let parts = task.taskDescription?.split(separator: "|", omittingEmptySubsequences: false)
+                guard let parts = parts, parts.count > 1 else { return nil }
+                return String(parts[1])
+            })
+            
+            let dir = self.outboxDir()
+            guard let files = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) else { return }
+            
+            let itemFiles = files.filter {
+                $0.pathExtension == "json" &&
+                ($0.lastPathComponent.hasPrefix("item_") || $0.lastPathComponent.hasPrefix("combined_item_"))
+            }
+            
+            var enqueued = 0
+            for itemURL in itemFiles {
+                guard let attrs = try? FileManager.default.attributesOfItem(atPath: itemURL.path),
+                      let mdate = attrs[.modificationDate] as? Date else { continue }
+                let age = Date().timeIntervalSince(mdate)
+                if age < Self.outboxMinRetryAge { continue }
+                
+                guard let data = try? Data(contentsOf: itemURL),
+                      let item = try? JSONDecoder().decode(OutboxItem.self, from: data) else {
+                    try? FileManager.default.removeItem(at: itemURL)
+                    continue
                 }
+                
+                let payloadURL = URL(fileURLWithPath: item.payloadPath)
+                guard FileManager.default.fileExists(atPath: payloadURL.path) else {
+                    // Orphaned metadata without a payload - clean up
+                    try? FileManager.default.removeItem(at: itemURL)
+                    continue
+                }
+                
+                if age > Self.outboxMaxItemAge {
+                    self.logMessage("Outbox: dropping stale item (\(Int(age / 3600))h old)")
+                    try? FileManager.default.removeItem(at: payloadURL)
+                    if let anchorPath = item.anchorPath {
+                        try? FileManager.default.removeItem(atPath: anchorPath)
+                    }
+                    try? FileManager.default.removeItem(at: itemURL)
+                    continue
+                }
+                
+                if inFlightPayloadPaths.contains(payloadURL.path) { continue }
+                
+                var req = URLRequest(url: endpoint)
+                req.httpMethod = "POST"
+                req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                self.applyAuth(to: &req, credential: credential)
+                
+                let task = self.session.uploadTask(with: req, fromFile: payloadURL)
+                task.taskDescription = [itemURL.path, payloadURL.path, item.anchorPath ?? ""].joined(separator: "|")
+                task.resume()
+                enqueued += 1
             }
-            task.resume()
+            
+            if enqueued > 0 {
+                self.logMessage("Outbox: enqueued \(enqueued) pending upload(s) to background session")
+            }
         }
     }
 }

--- a/Sources/OpenWearablesHealthSDK/Internal/Session.swift
+++ b/Sources/OpenWearablesHealthSDK/Internal/Session.swift
@@ -187,12 +187,19 @@ extension OpenWearablesHealthSDK {
     // MARK: - Get Sync Status
     
     internal func getSyncStatusDict() -> [String: Any] {
+        // Whether the initial full export (newest-first crawl of the whole history)
+        // has ever completed for this user. False = historical sync still pending
+        // or in progress; apps can use this to show a "keep the app open" hint.
+        let initialExportDone = defaults.bool(forKey: fullDoneKey())
+        
         if let state = loadSyncState() {
             return [
                 "hasResumableSession": state.hasProgress,
                 "sentCount": state.totalSentCount,
                 "completedTypes": state.completedTypes.count,
                 "isFullExport": state.fullExport,
+                "initialExportDone": initialExportDone,
+                "isSyncing": isSyncInProgress,
                 "createdAt": ISO8601DateFormatter().string(from: state.createdAt)
             ]
         } else {
@@ -201,6 +208,8 @@ extension OpenWearablesHealthSDK {
                 "sentCount": 0,
                 "completedTypes": 0,
                 "isFullExport": false,
+                "initialExportDone": initialExportDone,
+                "isSyncing": isSyncInProgress,
                 "createdAt": NSNull()
             ]
         }

--- a/Sources/OpenWearablesHealthSDK/Internal/Types.swift
+++ b/Sources/OpenWearablesHealthSDK/Internal/Types.swift
@@ -172,54 +172,6 @@ public enum HealthDataType: String, CaseIterable, Sendable {
 
 extension OpenWearablesHealthSDK {
 
-    // MARK: - Public API
-    internal func serialize(samples: [HKSample], type: HKSampleType) -> [String: Any] {
-        var workouts: [[String: Any]] = []
-        var records: [[String: Any]] = []
-        var sleep: [[String: Any]] = []
-        let df = ISO8601DateFormatter()
-
-        for s in samples {
-            if let w = s as? HKWorkout {
-                workouts.append(_mapWorkout(w))
-            } else if let q = s as? HKQuantitySample {
-                records.append(_mapQuantity(q))
-            } else if let c = s as? HKCategorySample {
-                if c.categoryType.identifier == HKCategoryTypeIdentifier.sleepAnalysis.rawValue {
-                    sleep.append(_mapSleep(c))
-                } else {
-                    records.append(_mapCategory(c))
-                }
-            } else if let corr = s as? HKCorrelation {
-                records.append(contentsOf: _mapCorrelation(corr))
-            } else {
-                records.append([
-                    "id": s.uuid.uuidString,
-                    "type": s.sampleType.identifier,
-                    "startDate": df.string(from: s.startDate),
-                    "endDate": df.string(from: s.endDate),
-                    "zoneOffset": _zoneOffsetString(metadata: s.metadata, date: s.startDate),
-                    "source": _mapSource(s.sourceRevision, device: s.device),
-                    "value": NSNull(),
-                    "unit": NSNull(),
-                    "parentId": NSNull(),
-                    "metadata": _metadataDict(s.metadata)
-                ])
-            }
-        }
-
-        return [
-            "provider": "apple",
-            "sdkVersion": OpenWearablesHealthSDK.sdkVersion,
-            "syncTimestamp": df.string(from: Date()),
-            "data": [
-                "workouts": workouts,
-                "records": records,
-                "sleep": sleep
-            ]
-        ]
-    }
-    
     // MARK: - Memory-efficient streaming serialization
     internal func serializeCombinedStreaming(samples: [HKSample]) -> [String: Any] {
         var workouts: [[String: Any]] = []

--- a/Sources/OpenWearablesHealthSDK/Internal/URLSessionDelegate.swift
+++ b/Sources/OpenWearablesHealthSDK/Internal/URLSessionDelegate.swift
@@ -10,81 +10,73 @@ extension OpenWearablesHealthSDK {
         let payloadPath = parts.count > 1 ? parts[1] : ""
         let anchorPath = parts.count > 2 ? parts[2] : ""
 
-        defer {
-            if !payloadPath.isEmpty { try? FileManager.default.removeItem(atPath: payloadPath) }
-            if error == nil, !itemPath.isEmpty { try? FileManager.default.removeItem(atPath: itemPath) }
+        if backgroundDataBuffer[task.taskIdentifier] != nil {
+            backgroundDataBuffer.removeValue(forKey: task.taskIdentifier)
         }
 
         if let error = error {
             let nsError = error as NSError
             if nsError.code != NSURLErrorCancelled {
-                NSLog("[OpenWearablesHealthSDK] background upload failed: \(error.localizedDescription)")
+                NSLog("[OpenWearablesHealthSDK] background upload failed: \(error.localizedDescription) - will retry later")
             }
             return
         }
 
-        if task.response is HTTPURLResponse {
-            if backgroundDataBuffer[task.taskIdentifier] != nil {
-                backgroundDataBuffer.removeValue(forKey: task.taskIdentifier)
+        let statusCode = (task.response as? HTTPURLResponse)?.statusCode ?? 0
+
+        if (200...299).contains(statusCode) {
+            if !itemPath.isEmpty,
+               let itemData = try? Data(contentsOf: URL(fileURLWithPath: itemPath)),
+               let item = try? JSONDecoder().decode(OutboxItem.self, from: itemData) {
+                // Saves anchors (combined & per-type), marks fullDone when applicable,
+                // and removes the item + anchor files.
+                handleSuccessfulUpload(
+                    itemPath: itemPath,
+                    anchorPath: anchorPath.isEmpty ? nil : anchorPath,
+                    wasFullExport: item.wasFullExport ?? false
+                )
             }
-        }
-        
-        if let http = task.response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
-            if http.statusCode == 401 {
-                if isApiKeyAuth {
-                    self.logMessage("Background 401 with API key - emitting auth error")
-                    DispatchQueue.main.async { [weak self] in
-                        self?.emitAuthError(statusCode: 401)
-                    }
-                } else {
-                    self.attemptTokenRefresh { [weak self] result in
-                        guard let self = self else { return }
-                        switch result {
-                        case .success:
-                            self.logMessage("Token refreshed after background 401 - retrying outbox...")
-                            self.retryOutboxIfPossible()
-                        case .authFailure:
-                            DispatchQueue.main.async { [weak self] in
-                                self?.emitAuthError(statusCode: 401)
-                            }
-                        case .networkError:
-                            self.logMessage("Token refresh failed (network) after background 401 - will retry later")
-                        }
-                    }
-                }
-            }
+            if !payloadPath.isEmpty { try? FileManager.default.removeItem(atPath: payloadPath) }
             return
         }
 
-        if !itemPath.isEmpty,
-           let itemData = try? Data(contentsOf: URL(fileURLWithPath: itemPath)),
-           let item = try? JSONDecoder().decode(OutboxItem.self, from: itemData) {
-            
-            if item.typeIdentifier == "combined" {
-                if !anchorPath.isEmpty,
-                   let anchorData = try? Data(contentsOf: URL(fileURLWithPath: anchorPath)),
-                   let anchorsDict = try? NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSDictionary.self, NSString.self, NSData.self], from: anchorData) as? [String: Data] {
-                    for (typeId, anchorData) in anchorsDict {
-                        saveAnchorData(anchorData, typeIdentifier: typeId, userKey: item.userKey)
-                    }
-                }
-                
-                if item.wasFullExport == true {
-                    let fullDoneKey = "fullDone.\(item.userKey)"
-                    let defaults = UserDefaults(suiteName: "com.openwearables.healthsdk.state") ?? .standard
-                    defaults.set(true, forKey: fullDoneKey)
-                    defaults.synchronize()
+        if statusCode == 401 {
+            // Keep the files - after a successful token refresh the retry pass
+            // picks them up again.
+            if isApiKeyAuth {
+                self.logMessage("Background 401 with API key - emitting auth error")
+                DispatchQueue.main.async { [weak self] in
+                    self?.emitAuthError(statusCode: 401)
                 }
             } else {
-                if !anchorPath.isEmpty,
-                   let anchorData = try? Data(contentsOf: URL(fileURLWithPath: anchorPath)) {
-                    saveAnchorData(anchorData, typeIdentifier: item.typeIdentifier, userKey: item.userKey)
+                self.attemptTokenRefresh { [weak self] result in
+                    guard let self = self else { return }
+                    switch result {
+                    case .success:
+                        self.logMessage("Token refreshed after background 401 - retrying outbox...")
+                        self.retryOutboxIfPossible()
+                    case .authFailure:
+                        DispatchQueue.main.async { [weak self] in
+                            self?.emitAuthError(statusCode: 401)
+                        }
+                    case .networkError:
+                        self.logMessage("Token refresh failed (network) after background 401 - will retry later")
+                    }
                 }
             }
-            if !anchorPath.isEmpty {
-                try? FileManager.default.removeItem(atPath: anchorPath)
-            }
+            return
         }
+
+        if (400...499).contains(statusCode) {
+            NSLog("[OpenWearablesHealthSDK] background upload rejected (HTTP \(statusCode)) - dropping item")
+            if !payloadPath.isEmpty { try? FileManager.default.removeItem(atPath: payloadPath) }
+            if !anchorPath.isEmpty { try? FileManager.default.removeItem(atPath: anchorPath) }
+            if !itemPath.isEmpty { try? FileManager.default.removeItem(atPath: itemPath) }
+            return
+        }
+
+        // 5xx / no response: keep the files for a later retry pass.
+        NSLog("[OpenWearablesHealthSDK] background upload failed (HTTP \(statusCode)) - will retry later")
     }
 
     public func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {

--- a/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
+++ b/Sources/OpenWearablesHealthSDK/OpenWearablesHealthSDK.swift
@@ -108,7 +108,6 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
     internal var session: URLSession!
     internal var foregroundSession: URLSession!
     internal var trackedTypes: [HKSampleType] = []
-    internal var chunkSize: Int = 1000
     internal var backgroundChunkSize: Int = 100
     internal var recordsPerChunk: Int = 2000
     
@@ -124,6 +123,16 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
     private let syncLock = NSLock()
     internal var fullSyncStartTime: Date?
     
+    internal var isSyncInProgress: Bool {
+        syncLock.lock()
+        defer { syncLock.unlock() }
+        return isSyncing
+    }
+    
+    // Outbox retry state
+    internal var isRetryingOutbox = false
+    internal let outboxRetryLock = NSLock()
+    
     // Network monitoring
     private var networkMonitor: NWPathMonitor?
     private let networkMonitorQueue = DispatchQueue(label: "health_sync_network_monitor")
@@ -132,6 +141,9 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
     // Protected data monitoring
     private var protectedDataObserver: NSObjectProtocol?
     internal var pendingSyncAfterUnlock = false
+    
+    // Foreground monitoring (resume sync when app returns to foreground)
+    private var foregroundObserver: NSObjectProtocol?
 
     // Per-user state (anchors)
     internal let defaults = UserDefaults(suiteName: "com.openwearables.healthsdk.state") ?? .standard
@@ -174,6 +186,11 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         let bgCfg = URLSessionConfiguration.background(withIdentifier: bgSessionId)
         bgCfg.isDiscretionary = false
         bgCfg.waitsForConnectivity = true
+        // Outbox retries go through this session. Serialize them (one connection at a
+        // time instead of a parallel burst) and cap how long a stale batch may linger
+        // in the system (default resource timeout is 7 days).
+        bgCfg.httpMaximumConnectionsPerHost = 1
+        bgCfg.timeoutIntervalForResource = 3600
         self.session = URLSession(configuration: bgCfg, delegate: self, delegateQueue: nil)
         
         let fgCfg = URLSessionConfiguration.default
@@ -259,6 +276,7 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         stopBackgroundDelivery()
         stopNetworkMonitoring()
         stopProtectedDataMonitoring()
+        stopForegroundMonitoring()
         cancelAllBGTasks()
         resetAllAnchors()
         clearSyncSession()
@@ -350,6 +368,7 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         startBackgroundDelivery()
         startNetworkMonitoring()
         startProtectedDataMonitoring()
+        startForegroundMonitoring()
         
         initialSyncKickoff { started in
             if started {
@@ -381,13 +400,9 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         stopBackgroundDelivery()
         stopNetworkMonitoring()
         stopProtectedDataMonitoring()
+        stopForegroundMonitoring()
         cancelAllBGTasks()
         OpenWearablesHealthSdkKeychain.setSyncActive(false)
-    }
-    
-    /// Trigger an immediate sync.
-    public func syncNow(completion: @escaping () -> Void) {
-        syncAll(fullExport: false, completion: completion)
     }
     
     /// Whether sync is currently active.
@@ -450,10 +465,15 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         startBackgroundDelivery()
         startNetworkMonitoring()
         startProtectedDataMonitoring()
+        startForegroundMonitoring()
         scheduleAppRefresh()
         scheduleProcessing()
         
-        if hasResumableSyncSession() {
+        // Resume when there is a session with progress, but also when the initial
+        // full export never completed (e.g. it was interrupted before its first
+        // successful upload - such a session has no progress to detect).
+        let fullDone = defaults.bool(forKey: fullDoneKey())
+        if hasResumableSyncSession() || !fullDone {
             logMessage("Found interrupted sync, will resume...")
             syncAll(fullExport: false) {
                 self.logMessage("Resumed sync completed")
@@ -514,7 +534,8 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         
         if observerBgTask == .invalid {
             observerBgTask = UIApplication.shared.beginBackgroundTask(withName: "health_combined_sync") {
-                self.logMessage("Background task expired")
+                self.logMessage("Background task expired - cancelling in-flight uploads")
+                self.cancelInFlightForegroundUploads()
                 UIApplication.shared.endBackgroundTask(self.observerBgTask)
                 self.observerBgTask = .invalid
             }
@@ -577,15 +598,32 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         logMessage("Types to sync (\(queryableTypes.count)): \(typeNames)")
         
         let existingState = loadSyncState()
-        let isResuming = existingState != nil && existingState!.hasProgress
-        
+        let fullDone = defaults.bool(forKey: fullDoneKey())
+
         let effectiveFullExport: Bool
-        if isResuming {
-            effectiveFullExport = existingState!.fullExport
-            logMessage("Resuming sync (fullExport: \(effectiveFullExport), \(existingState!.totalSentCount) already sent, \(existingState!.completedTypes.count) types done)")
+        if let state = existingState, state.fullExport {
+            effectiveFullExport = true
+        } else if !fullDone {
+            effectiveFullExport = true
         } else {
             effectiveFullExport = fullExport
-            logMessage("Starting streaming sync (fullExport: \(effectiveFullExport), \(queryableTypes.count) types)")
+        }
+        if effectiveFullExport && !fullExport {
+            logMessage("Escalating to full export (initial export not completed yet)")
+        }
+        
+        if let state = existingState, state.fullExport == effectiveFullExport {
+            if state.hasProgress {
+                logMessage("Resuming sync (fullExport: \(effectiveFullExport), \(state.totalSentCount) already sent, \(state.completedTypes.count) types done)")
+            } else {
+                logMessage("Continuing sync session (fullExport: \(effectiveFullExport), no progress yet)")
+            }
+        } else {
+            if let state = existingState {
+                logMessage("Replacing session (fullExport: \(state.fullExport)) - starting streaming sync (fullExport: \(effectiveFullExport))")
+            } else {
+                logMessage("Starting streaming sync (fullExport: \(effectiveFullExport), \(queryableTypes.count) types)")
+            }
             _ = startNewSyncState(fullExport: effectiveFullExport, types: queryableTypes)
         }
         
@@ -671,9 +709,13 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         }
         
         if !fullExport {
+            let fullDone = defaults.bool(forKey: fullDoneKey())
             for type in types where !rrState.completedTypes.contains(type.identifier) && rrState.anchorCursors[type.identifier] == nil {
                 if let anchor = loadAnchor(for: type) {
                     rrState.anchorCursors[type.identifier] = anchor
+                } else if !fullDone {
+                    logMessage("\(shortTypeName(type.identifier)): no anchor and full export not completed - skipping incremental for this type")
+                    rrState.completedTypes.insert(type.identifier)
                 }
             }
         }
@@ -742,7 +784,7 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
             let emptyDone = results.filter { $0.samples.isEmpty && $0.isDone }
             for result in emptyDone {
                 if !fullExport {
-                    self.updateTypeProgress(typeIdentifier: result.type.identifier, sentInChunk: 0, isComplete: true, anchorData: nil)
+                    self.updateTypeProgress(typeIdentifier: result.type.identifier, sentInChunk: 0, isComplete: true, anchorData: result.anchorData)
                 }
                 rrState.completedTypes.insert(result.type.identifier)
                 if fullExport { self.fireTypeCompletedLog(result.type.identifier) }
@@ -756,7 +798,8 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
             
             if allSamples.isEmpty {
                 if fullExport && !doneTypesForAnchorCapture.isEmpty {
-                    self.captureAnchorsForDoneTypes(types: doneTypesForAnchorCapture, index: 0, rrState: rrState) {
+                    self.captureAnchorsForDoneTypes(types: doneTypesForAnchorCapture, index: 0, rrState: rrState) { captureOk in
+                        guard captureOk else { completion(false); return }
                         self.processNextRound(
                             types: types, fullExport: fullExport, endpoint: endpoint,
                             chunkLimit: chunkLimit, rrState: rrState,
@@ -775,6 +818,19 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
             
             guard let freshCredential = self.authCredential else {
                 self.logMessage("No auth credential available for upload")
+                completion(false)
+                return
+            }
+            
+            // When the app runs in the background it lives on a ~30s task assertion.
+            // Don't start an upload that almost certainly cannot finish before
+            // expiration. The margin is deliberately small (a chunk upload takes
+            // ~1-3s) to use as much of the background window as possible: cursors
+            // and anchors only advance on a server 2xx, so even if the very last
+            // upload gets cut by expiration the batch is simply re-sent (and
+            // deduplicated server-side) when the sync resumes.
+            if let remaining = self.backgroundTimeRemainingIfInBackground(), remaining < 5 {
+                self.logMessage("Background time low (\(Int(remaining))s left) - pausing sync before next upload")
                 completion(false)
                 return
             }
@@ -809,7 +865,8 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
                 // Phase 4: For full export, capture anchors for done types
                 let fullExportDone = withData.filter { $0.isDone }.map { $0.type } + doneTypesForAnchorCapture.filter { t in !withData.contains(where: { $0.type == t }) }
                 if fullExport && !fullExportDone.isEmpty {
-                    self.captureAnchorsForDoneTypes(types: fullExportDone, index: 0, rrState: rrState) {
+                    self.captureAnchorsForDoneTypes(types: fullExportDone, index: 0, rrState: rrState) { captureOk in
+                        guard captureOk else { completion(false); return }
                         self.processNextRound(
                             types: types, fullExport: fullExport, endpoint: endpoint,
                             chunkLimit: chunkLimit, rrState: rrState,
@@ -883,20 +940,28 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
     
     private func captureAnchorsForDoneTypes(
         types: [HKSampleType], index: Int, rrState: RoundRobinState,
-        completion: @escaping () -> Void
+        completion: @escaping (Bool) -> Void
     ) {
         guard index < types.count else {
-            completion()
+            completion(true)
             return
         }
         
         let type = types[index]
         captureCurrentAnchor(for: type) { [weak self] anchor in
-            guard let self = self else { completion(); return }
-            var anchorData: Data? = nil
-            if let anchor = anchor {
-                anchorData = try? NSKeyedArchiver.archivedData(withRootObject: anchor, requiringSecureCoding: true)
+            guard let self = self else { completion(false); return }
+            
+            // Without a valid anchor the type must NOT be marked complete: the next
+            // incremental sync would run an anchored query from nil and re-crawl the
+            // whole history oldest-first. Pause the sync instead - on resume the type
+            // re-sends its last chunk (deduplicated server-side) and retries capture.
+            guard let anchor = anchor,
+                  let anchorData = try? NSKeyedArchiver.archivedData(withRootObject: anchor, requiringSecureCoding: true) else {
+                self.logMessage("  \(self.shortTypeName(type.identifier)): anchor capture failed - leaving type incomplete, pausing sync")
+                completion(false)
+                return
             }
+            
             self.updateTypeProgress(typeIdentifier: type.identifier, sentInChunk: 0, isComplete: true, anchorData: anchorData)
             rrState.completedTypes.insert(type.identifier)
             self.fireTypeCompletedLog(type.identifier)
@@ -997,19 +1062,24 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
                 }
                 
                 let samples = samplesOrNil ?? []
-                if samples.isEmpty {
-                    self.logMessage("  \(self.shortTypeName(type.identifier)): complete")
-                    completion(true, [], nil, nil, true)
-                    return
-                }
+                let deletedCount = deletedObjects?.count ?? 0
                 
                 var anchorData: Data? = nil
                 if let newAnchor = newAnchor {
                     anchorData = try? NSKeyedArchiver.archivedData(withRootObject: newAnchor, requiringSecureCoding: true)
                 }
                 
-                let isLastChunk = samples.count < chunkLimit
-                self.logMessage("  \(self.shortTypeName(type.identifier)): \(samples.count) samples")
+                if samples.isEmpty && deletedCount == 0 {
+                    self.logMessage("  \(self.shortTypeName(type.identifier)): complete")
+                    completion(true, [], newAnchor, anchorData, true)
+                    return
+                }
+                
+                // Deleted objects count against the query limit. Ignoring them made a
+                // chunk with samples + deletions look like the last one, so the anchor
+                // for the remaining (unfetched) data was never advanced.
+                let isLastChunk = (samples.count + deletedCount) < chunkLimit
+                self.logMessage("  \(self.shortTypeName(type.identifier)): \(samples.count) samples" + (deletedCount > 0 ? ", \(deletedCount) deleted" : ""))
                 completion(true, samples, newAnchor, anchorData, isLastChunk)
             }
         }
@@ -1030,9 +1100,25 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
             return HKQuery.predicateForSamples(withStart: start, end: nil, options: [])
         }()
         let query = HKAnchoredObjectQuery(type: type, predicate: syncPredicate, anchor: anchor, limit: limit) {
-            [weak self] _, samples, _, newAnchor, error in
+            [weak self] _, samples, deletedObjects, newAnchor, error in
             guard let self = self else { completion(nil); return }
-            let count = samples?.count ?? 0
+            
+            if let error = error {
+                // A failed step must not return a stale/nil anchor - the caller would
+                // persist it and the next incremental sync would re-crawl history.
+                if self.isProtectedDataError(error) {
+                    self.logMessage("\(self.shortTypeName(type.identifier)): protected data inaccessible during anchor capture - will retry after unlock")
+                    self.pendingSyncAfterUnlock = true
+                } else {
+                    self.logMessage("\(self.shortTypeName(type.identifier)): anchor capture failed - \(error.localizedDescription)")
+                }
+                completion(nil)
+                return
+            }
+            
+            // Deleted objects count against the query limit too. Ignoring them made
+            // the recursion stop early with an anchor that wasn't fully advanced.
+            let count = (samples?.count ?? 0) + (deletedObjects?.count ?? 0)
             if count >= limit {
                 self.captureAnchorStep(type: type, anchor: newAnchor, limit: limit, completion: completion)
             } else {
@@ -1048,6 +1134,30 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         isSyncing = false
         isInitialSyncInProgress = false
         syncLock.unlock()
+    }
+    
+    /// Returns the remaining background execution time when the app is in the
+    /// background, or `nil` when it is active (foreground has no time limit).
+    /// UIApplication state must be read on the main thread; sync uploads complete
+    /// on the main queue, so guard against deadlocking with `Thread.isMainThread`.
+    private func backgroundTimeRemainingIfInBackground() -> TimeInterval? {
+        let read: () -> TimeInterval? = {
+            guard UIApplication.shared.applicationState == .background else { return nil }
+            return UIApplication.shared.backgroundTimeRemaining
+        }
+        if Thread.isMainThread {
+            return read()
+        }
+        return DispatchQueue.main.sync(execute: read)
+    }
+    
+    /// Cancels in-flight foreground uploads. Called from BG task expiration handlers
+    /// so requests are terminated cleanly instead of being frozen mid-transfer when
+    /// the app gets suspended (which leaves the server with a dangling connection).
+    internal func cancelInFlightForegroundUploads() {
+        foregroundSession.getAllTasks { tasks in
+            for task in tasks { task.cancel() }
+        }
     }
     
     internal func cancelSync() {
@@ -1079,38 +1189,6 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         syncLock.unlock()
         
         logMessage("Sync cancelled")
-    }
-    
-    internal func syncType(_ type: HKSampleType, fullExport: Bool, completion: @escaping () -> Void) {
-        let anchor = fullExport ? nil : loadAnchor(for: type)
-        
-        let syncPredicate: NSPredicate? = {
-            guard let start = syncStartDate() else { return nil }
-            return HKQuery.predicateForSamples(withStart: start, end: nil, options: [])
-        }()
-        let query = HKAnchoredObjectQuery(type: type, predicate: syncPredicate, anchor: anchor, limit: chunkSize) {
-            [weak self] _, samplesOrNil, deletedObjects, newAnchor, error in
-            guard let self = self else { completion(); return }
-            guard error == nil else { completion(); return }
-
-            let samples = samplesOrNil ?? []
-            guard !samples.isEmpty else { completion(); return }
-            
-            guard let credential = self.authCredential, let endpoint = self.syncEndpoint else {
-                completion()
-                return
-            }
-
-            let payload = self.serialize(samples: samples, type: type)
-            self.enqueueBackgroundUpload(payload: payload, type: type, candidateAnchor: newAnchor, endpoint: endpoint, credential: credential) {
-                if samples.count == self.chunkSize {
-                    self.syncType(type, fullExport: false, completion: completion)
-                } else {
-                    completion()
-                }
-            }
-        }
-        healthStore.execute(query)
     }
     
     // MARK: - Logging
@@ -1355,6 +1433,54 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         pendingSyncAfterUnlock = false
     }
     
+    // MARK: - Foreground Monitoring
+    
+    /// Resumes an interrupted sync when the app returns to the foreground.
+    /// A sync paused in the background (e.g. "Background time low") had no
+    /// trigger to continue once the user reopened the app - observers only fire
+    /// on new HealthKit data and BG tasks run opportunistically much later.
+    internal func startForegroundMonitoring() {
+        guard foregroundObserver == nil else { return }
+        
+        foregroundObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.tryResumeAfterForeground()
+        }
+        
+        logMessage("Foreground monitoring started")
+    }
+    
+    internal func stopForegroundMonitoring() {
+        if let observer = foregroundObserver {
+            NotificationCenter.default.removeObserver(observer)
+            foregroundObserver = nil
+        }
+    }
+    
+    private func tryResumeAfterForeground() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            guard let self = self else { return }
+            
+            guard OpenWearablesHealthSdkKeychain.isSyncActive(), self.hasAuth else { return }
+            
+            let fullDone = self.defaults.bool(forKey: self.fullDoneKey())
+            guard self.hasResumableSyncSession() || !fullDone else { return }
+            
+            guard !self.isSyncInProgress else {
+                self.logMessage("Sync already in progress after foreground")
+                return
+            }
+            
+            self.logMessage("App returned to foreground - resuming sync...")
+            self.syncAll(fullExport: false) {
+                self.logMessage("Foreground resume sync completed")
+            }
+        }
+    }
+    
     internal func markNetworkError() {
         wasDisconnected = true
     }
@@ -1363,7 +1489,8 @@ public final class OpenWearablesHealthSDK: NSObject, URLSessionDelegate, URLSess
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
             guard let self = self else { return }
             
-            guard self.hasResumableSyncSession() else {
+            let fullDone = self.defaults.bool(forKey: self.fullDoneKey())
+            guard self.hasResumableSyncSession() || !fullDone else {
                 self.logMessage("No sync to resume")
                 return
             }


### PR DESCRIPTION
- Full export poisoning: SDK lost track that it was doing a full export when the first upload failed — next trigger flipped it to incremental without anchors, causing an infinite loop over old data. Now the full-export mode is sticky until it completes, and already-poisoned devices self-heal.
- Anchor loss: Anchor capture silently swallowed errors (locked phone) and ignored deleted objects in pagination — types got marked complete with a bad/nil anchor → re-crawl of entire history. Now errors pause sync, deleted objects count toward limits.
- Outbox burst: All pending retries fired in parallel on foreground session — died together on app suspend → ClientDisconnect storm. Now retries go through serialized background URLSession, survive app kill, with TTL and dedup.
- New fields: getSyncStatus() exposes initialExportDone and isSyncing.
- Cleanup: Removed dead legacy per-type sync code.